### PR TITLE
Record the LASTZ format in format.txt, not a name derived from it

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ The second step, has two sub-steps. First, use KegAlign to generate a list of LA
 ```bash
 # generate LASTZ keg
 python ./scripts/runner.py --diagonal-partition --format maf- --num-cpu 16 --num-gpu 1 --output-file data_package.tgz --output-type tarball --tool_directory ./scripts test-data/apple.fasta.gz test-data/orange.fasta.gz
-python ./scripts/package_output.py --format_selector maf --tool_directory ./scripts
+python ./scripts/package_output.py --output_format maf- --tool_directory ./scripts
 ```
 
 2) You can run KegAlign followed by our diagonal partitioning python script to generate the list of LASTZ commands.

--- a/scripts/package_output.py
+++ b/scripts/package_output.py
@@ -255,17 +255,19 @@ class bashCommandLineFile:
         return command_dict
 
     def _write_format(self) -> None:
-        if self.args.format_selector == "bam":
-            format_name = "bam"
-        elif self.args.format_selector == "maf":
-            format_name = "maf"
-        elif self.args.format_selector == "differences":
-            format_name = "interval"
-        else:
-            format_name = "tabular"
+        """Record the LASTZ output format in the tarball, for run_lastz_tarball.py.
 
+        ⚠ THE LASTZ FORMAT ITSELF, NOT A NAME DERIVED FROM IT. run_lastz_tarball.py reads this value
+        and maps it to an output datatype, and its table is keyed on lastz's own format names --
+        `sam-`, `maf+`, `lav+text`, `axt+`. This function used to map first and write the result, so
+        it emitted `interval` and `tabular`, which that table has no entries for. Only `bam` and
+        `maf` survived the round trip; `axt`, `lav` and `differences` were all mislabelled, silently,
+        because the reader falls back to `tabular` for anything it does not recognise.
+
+        Mapping belongs at the reading end, which is the end that knows what the names mean.
+        """
         with open("format.txt", "w") as ofh:
-            print(f"{format_name}", file=ofh)
+            print(f"{self.args.output_format}", file=ofh)
 
         self.package_file.add_format("format.txt")
 
@@ -306,7 +308,7 @@ class nodevisitor(bashlex.ast.nodevisitor):  # type: ignore[misc]
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--tool_directory", type=str, required=True, help="tool directory")
-    parser.add_argument("--format_selector", type=str, required=True, help="format selector")
+    parser.add_argument("--output_format", type=str, required=True, help="lastz output format")
     parser.add_argument("--debug", action="store_true", help="enable debug messages")
     args = parser.parse_args()
 


### PR DESCRIPTION
`package_output.py` writes `format.txt` into the tarball and `run_lastz_tarball.py` reads it back to decide the output datatype. The two ends did not agree on a vocabulary.

The writer mapped first and wrote the result -- `bam`, `maf`, `interval`, or `tabular` for everything else. The reader's table is keyed on lastz's own format names, and has no entry for `interval` or `tabular`, so it fell back to `tabular` for anything it did not recognise. Only `bam` and `maf` survived the round trip. `axt`, `lav` and `differences` were all mislabelled, silently, because a fallback is not an error.

The fix is to stop mapping at the writing end: record the lastz format itself and let the reader map it, which is the end that knows what the names mean. The reader needs no change here -- its table already covers the whole vocabulary.

⚠ THE COMMAND-LINE ARGUMENT IS RENAMED, `--format_selector` -> `--output_format`, because the old name described the old behaviour. The README example is updated with it, and gains a small consistency it was missing: it passed `--format maf-` to `runner.py` and `--format_selector maf` to this script, which is the same selector-versus-format confusion this commit removes. Both now read `maf-`.

Anyone scripting this directly must update the flag. If CLI stability matters more than clarity, keeping `--format_selector` as a deprecated alias would be a small addition -- say so and I will add it.

Verified against the contract test in richard-burhans/galaxytools, which parameterises over writer/reader pairings across both repositories:

    KEGALIGN_SRC=/path/to/KegAlign python -m pytest tests/test_format_contract.py

28 failures before, 20 after, and the pairing this commit is responsible for -- this repository's writer feeding that reader -- goes to ZERO. The remaining 20 all involve this repository's `run_lastz_tarball.py`, whose format table is the next change.