### PR TITLE
Support --inner, and stop queueing commands from a failed kegalign run

### DIFF
--- a/scripts/runner.py
+++ b/scripts/runner.py
@@ -19,6 +19,17 @@ SENTINEL_VALUE: typing.Final = "SENTINEL"
 RUSAGE_ATTRS: typing.Final = ["ru_utime", "ru_stime", "ru_maxrss", "ru_minflt", "ru_majflt", "ru_inblock", "ru_oublock", "ru_nvcsw", "ru_nivcsw"]
 
 
+def inject_inner(line: str, inner: typing.Optional[int]) -> str:
+    if inner is None or " --inner=" in line:
+        return line
+
+    new_line, count = re.subn(r"( --strand=(?:minus|plus))", rf"\1 --inner={inner}", line, count=1)
+    if count == 0:
+        sys.exit(f"Unable to inject --inner into unexpected lastz command: {line}")
+
+    return new_line
+
+
 class LastzCommands:
     def __init__(self) -> None:
         self.commands: dict[str, LastzCommand] = {}
@@ -37,7 +48,7 @@ class LastzCommands:
 
 
 class LastzCommand:
-    lastz_command_regex = re.compile(r"lastz (.+?)?ref\.2bit\[nameparse=darkspace\]\[multiple\]\[subset=ref_block(\d+)\.name\] (.+?)?query\.2bit\[nameparse=darkspace\]\[subset=query_block(\d+)\.name] --format=(\S+) --ydrop=(\d+) --gappedthresh=(\d+) --strand=(minus|plus)(?: --ambiguous=(\S+))?(?: --(notrivial))?(?: --scores=(\S+))?(?: --inner=(\d+))? --segments=tmp(\d+)\.block(\d+)\.r(\d+)\.(minus|plus)(?:\.split(\d+))?\.segments --output=tmp(\d+)\.block(\d+)\.r(\d+)\.(minus|plus)(?:\.split(\d+))?\.(\S+) 2> tmp(\d+)\.block(\d+)\.r(\d+)\.(minus|plus)(?:\.split(\d+))?\.err")
+    lastz_command_regex = re.compile(r"lastz (.+?)?ref\.2bit\[nameparse=darkspace\]\[multiple\]\[subset=ref_block(\d+)\.name\] (.+?)?query\.2bit\[nameparse=darkspace\]\[subset=query_block(\d+)\.name] --format=(\S+) --ydrop=(\d+) --gappedthresh=(\d+) --strand=(minus|plus)(?: --inner=(\d+))?(?: --ambiguous=(\S+))?(?: --(notrivial))?(?: --scores=(\S+))? --segments=tmp(\d+)\.block(\d+)\.r(\d+)\.(minus|plus)(?:\.split(\d+))?\.segments --output=tmp(\d+)\.block(\d+)\.r(\d+)\.(minus|plus)(?:\.split(\d+))?\.(\S+) 2> tmp(\d+)\.block(\d+)\.r(\d+)\.(minus|plus)(?:\.split(\d+))?\.err")
 
     def __init__(self, line: str) -> None:
         self.line = line
@@ -50,11 +61,11 @@ class LastzCommand:
         self.output_format: str = ''
         self.ydrop: int = 0
         self.gappedthresh: int = 0
+        self.inner: int | None = None
         self.strand: int | None = None
         self.ambiguous: bool = False
         self.nontrivial: bool = False
         self.scoring: str | None = None
-        self.inner: int | None = None
         self.segments_filename: str = ''
         self.output_filename: str = ''
         self.error_filename: str = ''
@@ -92,25 +103,25 @@ class LastzCommand:
             f"--strand={strand}"
         ]
 
-        ambiguous = match.group(9)
+        inner = match.group(9)
+        if inner is not None:
+            self.inner = int(inner)
+            self.args.append(f"--inner={self.inner}")
+
+        ambiguous = match.group(10)
         if ambiguous is not None:
             self.ambiguous = True
             self.args.append(f"--ambiguous={ambiguous}")
 
-        nontrivial = match.group(10)
+        nontrivial = match.group(11)
         if nontrivial is not None:
             self.nontrivial = True
             self.args.append("--nontrivial")
 
-        scoring = match.group(11)
+        scoring = match.group(12)
         if scoring is not None:
             self.scoring = scoring
             self.args.append(f"--scoring={scoring}")
-
-        inner = match.group(12)
-        if inner is not None:
-            self.inner = int(inner)
-            self.args.append(f"--inner={inner}")
 
         tmp_no = int(match.group(13))
         block_no = int(match.group(14))
@@ -390,7 +401,7 @@ def run_kegalign(args: argparse.Namespace, num_sentinel: int, kegalign_args: lis
 
     # use the currently existing output file if it exists
     if args.debug:
-        skip_kegalign = load_kegalign_output("lastz-commands.txt", kegalign_q)
+        skip_kegalign = load_kegalign_output("lastz-commands.txt", args.inner, kegalign_q)
 
     if not skip_kegalign:
         run_args = ["kegalign"]
@@ -405,16 +416,17 @@ def run_kegalign(args: argparse.Namespace, num_sentinel: int, kegalign_args: lis
 
         process = subprocess.run(run_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, bufsize=1, text=True)
 
-        for line in process.stdout.splitlines():
-            commands.add(line)
-            kegalign_q.put(line)
-
         if len(process.stderr) != 0:
             for line in process.stderr.splitlines():
                 print(line, file=sys.stderr, flush=True)
 
         if process.returncode != 0:
             sys.exit(f"Error: kegalign exited with returncode {process.returncode}")
+
+        for line in process.stdout.splitlines():
+            line = inject_inner(line, args.inner)
+            commands.add(line)
+            kegalign_q.put(line)
 
         if args.debug:
             ns: int = time.monotonic_ns() - beg
@@ -430,7 +442,7 @@ def run_kegalign(args: argparse.Namespace, num_sentinel: int, kegalign_args: lis
     return skip_kegalign
 
 
-def load_kegalign_output(filename: str, kegalign_q: queue.Queue[str]) -> bool:
+def load_kegalign_output(filename: str, inner: typing.Optional[int], kegalign_q: queue.Queue[str]) -> bool:
     load_success = False
 
     r_beg = resource.getrusage(resource.RUSAGE_SELF)
@@ -440,6 +452,7 @@ def load_kegalign_output(filename: str, kegalign_q: queue.Queue[str]) -> bool:
         with open(filename) as f:
             for line in f:
                 line = line.rstrip("\n")
+                line = inject_inner(line, inner)
                 kegalign_q.put(line)
         load_success = True
     except FileNotFoundError:
@@ -464,6 +477,7 @@ def parse_args() -> tuple[argparse.Namespace, list[str]]:
     parser.add_argument("--diagonal-partition", action="store_true", help="run diagonal partition optimization")
     parser.add_argument("--nogapped", action="store_true", help="don't perform gapped extension stage")
     parser.add_argument("--markend", action="store_true", help="write a marker line just before completion")
+    parser.add_argument("--inner", type=int, help="pass --inner to LASTZ command generation and execution")
     parser.add_argument("--num-gpu", default=-1, type=int, help="number of GPUs to use (default: %(default)s [use all GPUs])")
     parser.add_argument("--num-cpu", default=-1, type=int, help="number of CPUs to use (default: %(default)s [use all CPUs])")
     parser.add_argument("--debug", action="store_true", help="print debug messages")


### PR DESCRIPTION
Two changes, and the second is a bug fix that happened to travel with the first.

--inner
    `inject_inner()` adds `--inner=<n>` to each generated lastz command, and
    `lastz_command_regex` is reordered to parse it -- lastz accepts `--inner`
    after `--strand`, so the pattern places it there and the capture groups after
    it shift by one. It is threaded through both paths that produce commands:
    kegalign's stdout, and `load_kegalign_output()` when commands are read back
    from `lastz-commands.txt`.

⚠ COMMANDS WERE QUEUED BEFORE THE RETURN CODE WAS CHECKED
    The stdout loop ran immediately after `subprocess.run()`, so a kegalign
    invocation that failed still had its partial output parsed, added to
    `commands`, and pushed onto `kegalign_q` -- where worker threads could begin
    executing it -- before the `returncode != 0` check exited. On a failure that
    produced some output before dying, that is lastz work started against a
    command list nobody should have trusted.

    The loop now runs after the stderr report and the return-code check, so
    nothing is queued unless kegalign actually succeeded.

This file is duplicated in richard-burhans/galaxytools, where both changes were made and have been running. This brings the two copies back together; the divergence is being closed file by file so that the Galaxy wrapper can eventually stop vendoring these scripts altogether and call the ones this package already installs to $PREFIX/bin.

Nothing here is Galaxy-specific: no Galaxy imports, no tool-directory assumptions, no new dependencies.