### PR TITLE
Map the whole LASTZ format vocabulary, and compress axt/maf output

### DIFF
--- a/scripts/run_lastz_tarball.py
+++ b/scripts/run_lastz_tarball.py
@@ -2,6 +2,8 @@
 
 import argparse
 import concurrent.futures
+import contextlib
+import gzip
 import json
 import multiprocessing
 import os
@@ -14,6 +16,16 @@ import tarfile
 import tempfile
 import time
 import typing
+
+
+@contextlib.contextmanager
+def open_file(filename: str):
+    if filename.endswith(".gz"):
+        with gzip.open(filename, "wt", compresslevel=6) as f:
+            yield f
+    else:
+        with open(filename, "w") as f:
+            yield f
 
 
 lastz_output_format_regex = re.compile(
@@ -214,10 +226,23 @@ class BatchTar:
         except FileNotFoundError:
             sys.exit(f"ERROR: input tarball missing galaxy/format.txt: {self.pathname}")
 
-        if format_name in ["bam", "maf"]:
-            self.format_name = format_name
-        elif format_name == "differences":
-            self.format_name = "interval"
+        format_map = {
+            "axt": "axt",
+            "axt+": "axt",
+            "cigar": "cigar",
+            "differences": "interval",
+            "lav": "lav",
+            "lav+text": "lav",
+            "maf": "maf",
+            "maf+": "maf",
+            "maf-": "maf",
+            "sam": "sam",
+            "sam-": "sam",
+            "softsam": "sam",
+            "softsam-": "sam"
+        }
+
+        self.format_name = format_map.get(format_name, "tabular")
 
 
 class TarRunner:
@@ -324,6 +349,8 @@ class TarRunner:
             while not output_queue.empty():
                 run_time = output_queue.get()
                 run_times.append(run_time)
+                if self.debug:
+                    print(f"lastz took {run_time}", file=sys.stderr, flush=True)
 
             if found_falures:
                 sys.exit("lastz command failed")
@@ -341,10 +368,12 @@ class TarRunner:
             sys.exit(f"ERROR: expecting a single output file, found {num_output_files}")
 
         final_output_format = self.batch_tar.final_output_format()
+        if final_output_format in ["axt", "maf"]:
+            final_output_format = f"{final_output_format}.gz"
 
         for file_type, file_list in self.output_files.items():
-            with open(f"output.{final_output_format}", "w") as ofh:
-                if final_output_format == "maf":
+            with open_file(f"output.{final_output_format}") as ofh:
+                if final_output_format == "maf.gz":
                     print("##maf version=1", file=ofh)
 
                 for filename in file_list:


### PR DESCRIPTION
`_load_format()` recognised three values -- `bam`, `maf`, `differences` -- and left `self.format_name` at its `tabular` default for everything else. lastz emits many more format names than that, so `axt`, `axt+`, `lav`, `lav+text`, `maf+`, `maf-`, `sam`, `sam-`, `softsam`, `softsam-` and `cigar` all ended up typed `tabular`, silently, because a default is not an error.

They are now a table, and the table is the only place format names are interpreted. Together with the companion change to `package_output.py` -- which stops mapping at the writing end and records the lastz format itself -- the round trip is correct for every format the pair can produce.

⚠ AXT AND MAF OUTPUT IS NOW GZIPPED, WHICH IS A USER-VISIBLE CHANGE.
    `output.maf` becomes `output.maf.gz`, and likewise for axt. Alignment output
    in these formats is highly compressible and frequently enormous, so this is
    worth having -- but anyone consuming `output.maf` by name will need to
    update, and it belongs in the release notes rather than passing quietly.
    `open_file()` picks gzip or plain by extension; no other format is affected.

Also adds a debug line reporting each lastz command's runtime, behind --debug.

Verified with the contract test in richard-burhans/galaxytools, which parameterises over writer/reader pairings across both repositories:

    KEGALIGN_SRC=/path/to/KegAlign python -m pytest tests/test_format_contract.py

This change alone takes 28 failures to 18. WITH the package_output.py change it goes to ZERO -- 90 passed, every pairing clean, including a tarball written by one repository's copy and read by the other's. Neither change reaches zero on its own, because they are the two ends of one contract.

This file is duplicated in richard-burhans/galaxytools, where these changes were made and have been running. Nothing here is Galaxy-specific.