### PR TITLE
Build as C++17, which CUDA 13 requires

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,6 @@
-cmake_minimum_required (VERSION 3.10)
+# 3.30, not 3.10: CMP0167 below is a 3.30 policy and cmake_policy(SET ...) is an ERROR on a CMake
+# that does not know it, so 3.30 has been the real floor for as long as that line has been here.
+cmake_minimum_required (VERSION 3.30)
 cmake_policy(SET CMP0104 NEW)   # CMake 3.18
 cmake_policy(SET CMP0128 NEW)   # CMake 3.22
 cmake_policy(SET CMP0146 NEW)   # CMake 3.27
@@ -14,7 +16,7 @@ set(CMAKE_CUDA_COMPILER nvcc)
 set(CMAKE_CUDA_COMPILER_ENV_VAR "CUDACXX")
 set(CMAKE_CUDA_HOST_COMPILER_ENV_VAR "CUDAHOSTCXX")
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O4 -std=c++14 -l c -lboost_program_options")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O4 -std=c++17 -l c -lboost_program_options")
 
 find_package(TBB REQUIRED tbbmalloc tbbmalloc_proxy tbb_preview)
 
@@ -46,7 +48,11 @@ set_target_properties(
     kegalign 
     PROPERTIES 
       CUDA_SEPARABLE_COMPILATION ON
-      CUDA_STANDARD 14
+      # CUDA 13 bundles a CCCL whose Thrust, CUB and libcu++ headers all refuse to compile below
+      # C++17. REQUIRED so a toolchain that cannot provide it fails here rather than quietly
+      # dropping to an older standard and failing later inside those headers.
+      CUDA_STANDARD 17
+      CUDA_STANDARD_REQUIRED ON
       )
 
 target_compile_options(kegalign PRIVATE -DTBB_SUPPRESS_DEPRECATED_MESSAGES)


### PR DESCRIPTION
The CUDA 13.0 build fails in the CCCL headers the toolkit bundles:

    Thrust requires at least C++17
    libcu++ requires at least C++ 17
    CUB requires at least C++17
    make[2]: *** [CMakeFiles/kegalign.dir/common/seed_pos_table.cu.o] Error 1

CUDA 13 ships a CCCL that will not compile below C++17, and this project asked for 14 in two places -- `-std=c++14` in CMAKE_CXX_FLAGS, covering the .cpp sources, and `CUDA_STANDARD 14`, covering the .cu sources. Both move together: the two sets share headers, so compiling them to different standards is an ODR hazard even where it happens to link.

CUDA_STANDARD_REQUIRED is set at the same time. Without it CMake may silently fall back to an older standard when the toolchain cannot provide the requested one -- which is exactly the failure being fixed here, arriving later and less legibly, from inside somebody else's headers.

cmake_minimum_required goes 3.10 -> 3.30. That is not a new requirement, it is an honest one: CMP0167 four lines below is a 3.30 policy, and cmake_policy(SET ...) is an ERROR on a CMake that does not know the policy, so 3.30 has been the real floor for as long as that line has existed. 3.10 also could not have promised the CUDA_STANDARD handling this file depends on.

⚠ NOT VERIFIED BY A BUILD. There is no GPU or CUDA toolkit here, so this is reasoned from the error text and the CUDA 13 CCCL requirement, not compiled. The feedstock's CUDA 13.0 job is the test. Two things to watch there: that the C++17 switch does not disturb the CUDA 12.9 build, whose CCCL is content with either; and that nothing in the sources relies on C++14-only behaviour -- C++17 removes a few things, though nothing this code appears to use.

Also unresolved, and deliberately left alone: `-O4` is not a GCC optimisation level (it caps at -O3, so that flag has silently meant -O3 all along), and `-l c` carries an unusual space. Neither breaks the build, and neither belongs in a change about the C++ standard.