### PR TITLE
EXPERIMENT: print which CUDA architectures reach the build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,10 +6,32 @@ cmake_policy(SET CMP0128 NEW)   # CMake 3.22
 cmake_policy(SET CMP0146 NEW)   # CMake 3.27
 cmake_policy(SET CMP0167 NEW)   # CMake 3.30
 
-execute_process(COMMAND bash "-c" "${CMAKE_SOURCE_DIR}/scripts/get-cuda-arches.bash" OUTPUT_VARIABLE KEGALIGN_CUDA_ARCHITECTURES)
+execute_process(COMMAND bash "-c" "${CMAKE_SOURCE_DIR}/scripts/get-cuda-arches.bash"
+                OUTPUT_VARIABLE KEGALIGN_CUDA_ARCHITECTURES
+                RESULT_VARIABLE KEGALIGN_ARCH_SCRIPT_RESULT
+                ERROR_VARIABLE  KEGALIGN_ARCH_SCRIPT_STDERR)
 set(CMAKE_CUDA_ARCHITECTURES "${KEGALIGN_CUDA_ARCHITECTURES}")
 
+# ---- TEMPORARY DIAGNOSTIC, NOT FOR MERGE -------------------------------------
+# Which architectures actually reach nvcc? The shipped 0.1.2.10 and 0.1.2.11
+# binaries both record 14 in __CUDA_ARCH_LIST__, but this script emits 19. Print
+# every candidate source so we can see who drops the other five.
+message(STATUS "KEGALIGN_DIAG script_exit=[${KEGALIGN_ARCH_SCRIPT_RESULT}]")
+message(STATUS "KEGALIGN_DIAG script_stderr=[${KEGALIGN_ARCH_SCRIPT_STDERR}]")
+message(STATUS "KEGALIGN_DIAG script_stdout=[${KEGALIGN_CUDA_ARCHITECTURES}]")
+message(STATUS "KEGALIGN_DIAG env_CUDAARCHS=[$ENV{CUDAARCHS}]")
+message(STATUS "KEGALIGN_DIAG env_cuda_compiler_version=[$ENV{cuda_compiler_version}]")
+message(STATUS "KEGALIGN_DIAG before_project=[${CMAKE_CUDA_ARCHITECTURES}]")
+# ------------------------------------------------------------------------------
+
 project(kegalign LANGUAGES C CXX CUDA)
+
+# ---- TEMPORARY DIAGNOSTIC, NOT FOR MERGE -------------------------------------
+message(STATUS "KEGALIGN_DIAG after_project=[${CMAKE_CUDA_ARCHITECTURES}]")
+list(LENGTH CMAKE_CUDA_ARCHITECTURES KEGALIGN_DIAG_N)
+message(STATUS "KEGALIGN_DIAG after_project_count=[${KEGALIGN_DIAG_N}]")
+message(STATUS "KEGALIGN_DIAG cmake_version=[${CMAKE_VERSION}] policy_floor=[${CMAKE_MINIMUM_REQUIRED_VERSION}]")
+# ------------------------------------------------------------------------------
 
 set(CMAKE_CUDA_COMPILER nvcc)
 
@@ -60,4 +82,14 @@ target_compile_options(kegalign PRIVATE -DTBB_SUPPRESS_DEPRECATED_MESSAGES)
 target_link_libraries(kegalign PRIVATE ${LIBS})
 
 target_include_directories(kegalign PRIVATE ${PROJECT_SOURCE_DIR}/common/ ${PROJECT_SOURCE_DIR}/src/)
+
+# ---- TEMPORARY DIAGNOSTIC, NOT FOR MERGE -------------------------------------
+# The target property is what actually becomes -gencode; it can differ from the
+# directory variable above.
+get_target_property(KEGALIGN_DIAG_TGT kegalign CUDA_ARCHITECTURES)
+message(STATUS "KEGALIGN_DIAG target_property=[${KEGALIGN_DIAG_TGT}]")
+list(LENGTH KEGALIGN_DIAG_TGT KEGALIGN_DIAG_TGT_N)
+message(STATUS "KEGALIGN_DIAG target_property_count=[${KEGALIGN_DIAG_TGT_N}]")
+# ------------------------------------------------------------------------------
+
 


### PR DESCRIPTION
Not for merge. Diagnostic only, to close the last gap in the CUDA 12.9 regression from #39.

What is established so far:

  - The failure is CCCL's namespace macro, not our code. Thrust builds its ABI namespace with _CCCL_PP_SPLICE_WITH(_, THRUST, THRUST_VERSION, SM, __CUDA_ARCH_LIST__, NS) and CCCL's argument counter breaks past a certain width. Reproduced locally with cpp alone: <=15 architectures correct, 16 silently garbled, 17-26 hard error, >=27 silently garbled. Our CI error is the 17-26 band.

  - get-cuda-arches.bash emits 19 architectures for CUDA 12.9, and nvcc defines __CUDA_ARCH_LIST__ with all 19 when given 19 -gencode flags.

  - Yet the shipped kegalign 0.1.2.10 and 0.1.2.11 binaries BOTH record only 14 in that macro -- 500,520,600,610,700,750,800,860,890,900,1000,1030, 1200,1210 -- dropping 53, 62, 72, 87 and 101. 14 architectures is 18 macro arguments, just inside the safe band, which is why those builds were green.

So something between CMakeLists.txt and nvcc drops five architectures, and raising cmake_minimum_required from 3.10 to 3.30 appears to stop it doing so. This prints every candidate source at configure time, before the build gets far enough to fail, so we can see which one changes.

Expected if the theory holds: script_stdout has 19, and after_project/ target_property also have 19 -- where the floor-3.10 build ends at 14. If they all read 14 the theory is wrong, which is worth knowing just as much.