### PR TITLE
Fix the CUDA 12.9 build: stop overwriting CUDAARCHS, and guard the policy settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,21 @@
-# 3.30, not 3.10: CMP0167 below is a 3.30 policy and cmake_policy(SET ...) is an ERROR on a CMake
-# that does not know it, so 3.30 has been the real floor for as long as that line has been here.
-cmake_minimum_required (VERSION 3.30)
-cmake_policy(SET CMP0104 NEW)   # CMake 3.18
-cmake_policy(SET CMP0128 NEW)   # CMake 3.22
-cmake_policy(SET CMP0146 NEW)   # CMake 3.27
-cmake_policy(SET CMP0167 NEW)   # CMake 3.30
+cmake_minimum_required (VERSION 3.10)
+
+# if(POLICY ...) around each of these, because cmake_policy(SET ...) on a policy
+# the running CMake has never heard of is an error. That -- not the floor -- is
+# what these lines actually require, and guarding them is the idiomatic way to
+# say so.
+if(POLICY CMP0104)
+    cmake_policy(SET CMP0104 NEW)   # CMake 3.18
+endif()
+if(POLICY CMP0128)
+    cmake_policy(SET CMP0128 NEW)   # CMake 3.22
+endif()
+if(POLICY CMP0146)
+    cmake_policy(SET CMP0146 NEW)   # CMake 3.27
+endif()
+if(POLICY CMP0167)
+    cmake_policy(SET CMP0167 NEW)   # CMake 3.30
+endif()
 
 execute_process(COMMAND bash "-c" "${CMAKE_SOURCE_DIR}/scripts/get-cuda-arches.bash" OUTPUT_VARIABLE KEGALIGN_CUDA_ARCHITECTURES)
 set(CMAKE_CUDA_ARCHITECTURES "${KEGALIGN_CUDA_ARCHITECTURES}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,10 @@
 cmake_minimum_required (VERSION 3.10)
 
 # if(POLICY ...) around each of these, because cmake_policy(SET ...) on a policy
-# the running CMake has never heard of is an error. That -- not the floor -- is
-# what these lines actually require, and guarding them is the idiomatic way to
-# say so.
+# the running CMake has never heard of is an error. Guarding them is what lets
+# this file name a low floor and still ask for NEW behaviour where it is
+# available -- raising cmake_minimum_required is not the way to do that, and
+# doing so once changed which CUDA architectures this build used.
 if(POLICY CMP0104)
     cmake_policy(SET CMP0104 NEW)   # CMake 3.18
 endif()
@@ -17,8 +18,9 @@ if(POLICY CMP0167)
     cmake_policy(SET CMP0167 NEW)   # CMake 3.30
 endif()
 
-execute_process(COMMAND bash "-c" "${CMAKE_SOURCE_DIR}/scripts/get-cuda-arches.bash" OUTPUT_VARIABLE KEGALIGN_CUDA_ARCHITECTURES)
-set(CMAKE_CUDA_ARCHITECTURES "${KEGALIGN_CUDA_ARCHITECTURES}")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
+include(SelectCudaArchitectures)
+kegalign_select_cuda_architectures(CMAKE_CUDA_ARCHITECTURES)
 
 project(kegalign LANGUAGES C CXX CUDA)
 

--- a/cmake/SelectCudaArchitectures.cmake
+++ b/cmake/SelectCudaArchitectures.cmake
@@ -1,0 +1,111 @@
+# Choosing the CUDA architectures to build for.
+#
+# WHY THIS IS NOT JUST `set(CMAKE_CUDA_ARCHITECTURES <our list>)`.
+#
+# Packagers already know which architectures they want. conda-forge exports
+# CUDAARCHS, which CMake reads, and its list is maintained by the people who run
+# the CUDA migrations -- it uses the a/f variants where they matter (90a, 100f,
+# 103f, 120a, 121f) and ends in 121-virtual so PTX is embedded for future GPUs.
+# Overwriting that with a list of our own is both presumptuous and, as it turned
+# out, dangerous: the longer list broke the build. So an architecture list that
+# reaches us from outside always wins, and get-cuda-arches.bash is the fallback
+# for people building this by hand.
+#
+# THE LIMIT. CCCL opens Thrust's ABI namespace with
+#
+#     _CCCL_PP_SPLICE_WITH(_, THRUST, THRUST_VERSION, SM, __CUDA_ARCH_LIST__, NS)
+#
+# whose argument count is 4 + (distinct architectures). CCCL's argument counter
+# does not survive arbitrary widths. Measured directly against the CUDA 12.9.27
+# headers, with the preprocessor alone:
+#
+#     <= 15 architectures   expands correctly
+#        16 architectures   expands to the WRONG namespace, silently
+#     17 - 26 architectures   hard error inside Thrust and CUB
+#     >= 27 architectures   silently wrong again
+#
+# 15 is therefore the last width known to be correct, and going over it is
+# checked here so the failure is one legible message rather than a thousand
+# lines of macro errors -- or, at exactly 16, no error at all and a binary whose
+# Thrust symbols are in a namespace nobody meant.
+set(KEGALIGN_CCCL_MAX_ARCHITECTURES 15)
+
+# Captured at include time. CMAKE_CURRENT_FUNCTION_LIST_DIR would be the natural
+# thing to use inside the function below, but it only exists from CMake 3.17 and
+# this file must not quietly depend on more than cmake_minimum_required claims.
+set(KEGALIGN_CMAKE_MODULE_DIR "${CMAKE_CURRENT_LIST_DIR}")
+
+# Count the distinct architectures in a CMAKE_CUDA_ARCHITECTURES value.
+# `-real` and `-virtual` suffixes, and the `a`/`f` variants, all name the same
+# architecture as far as __CUDA_ARCH_LIST__ is concerned: 90, 90a and 90-real
+# are one architecture, not three.
+function(kegalign_count_cuda_architectures out_var architectures)
+    set(_numbers "")
+    foreach(_entry IN LISTS architectures)
+        string(REGEX REPLACE "-(real|virtual)$" "" _entry "${_entry}")
+        string(REGEX REPLACE "[af]$" "" _entry "${_entry}")
+        if(_entry MATCHES "^[0-9]+$")
+            list(APPEND _numbers "${_entry}")
+        endif()
+    endforeach()
+    if(_numbers)
+        list(REMOVE_DUPLICATES _numbers)
+    endif()
+    list(LENGTH _numbers _count)
+    set(${out_var} "${_count}" PARENT_SCOPE)
+endfunction()
+
+# kegalign_select_cuda_architectures(<out-var> [SCRIPT <path>])
+#
+# Sets <out-var> to the architectures to build for, in precedence order:
+#   1. CMAKE_CUDA_ARCHITECTURES already set by the caller (-D, or a toolchain file)
+#   2. the CUDAARCHS environment variable
+#   3. scripts/get-cuda-arches.bash, which asks nvcc
+function(kegalign_select_cuda_architectures out_var)
+    cmake_parse_arguments(PARSE_ARGV 1 _arg "" "SCRIPT" "")
+
+    if(NOT _arg_SCRIPT)
+        set(_arg_SCRIPT "${KEGALIGN_CMAKE_MODULE_DIR}/../scripts/get-cuda-arches.bash")
+    endif()
+
+    if(DEFINED CMAKE_CUDA_ARCHITECTURES AND NOT CMAKE_CUDA_ARCHITECTURES STREQUAL "")
+        set(_architectures "${CMAKE_CUDA_ARCHITECTURES}")
+        set(_source "the caller")
+    elseif(DEFINED ENV{CUDAARCHS} AND NOT "$ENV{CUDAARCHS}" STREQUAL "")
+        set(_architectures "$ENV{CUDAARCHS}")
+        set(_source "the CUDAARCHS environment variable")
+    else()
+        execute_process(
+            COMMAND bash "-c" "${_arg_SCRIPT}"
+            OUTPUT_VARIABLE _architectures
+            RESULT_VARIABLE _result
+            ERROR_VARIABLE _stderr)
+        if(NOT _result EQUAL 0)
+            message(FATAL_ERROR
+                "${_arg_SCRIPT} failed (exit ${_result}): ${_stderr}")
+        endif()
+        string(STRIP "${_architectures}" _architectures)
+        if(_architectures STREQUAL "")
+            message(FATAL_ERROR
+                "${_arg_SCRIPT} produced no architectures. Set CUDAARCHS or pass "
+                "-DCMAKE_CUDA_ARCHITECTURES=... to choose them explicitly.")
+        endif()
+        set(_source "get-cuda-arches.bash")
+    endif()
+
+    kegalign_count_cuda_architectures(_count "${_architectures}")
+    if(_count GREATER KEGALIGN_CCCL_MAX_ARCHITECTURES)
+        message(FATAL_ERROR
+            "Building for ${_count} CUDA architectures, from ${_source}, but CCCL's "
+            "Thrust/CUB namespace macro only expands correctly for up to "
+            "${KEGALIGN_CCCL_MAX_ARCHITECTURES}. Above that it either fails deep "
+            "inside the Thrust headers or, at exactly 16, silently produces the "
+            "wrong namespace. Narrow the list with CUDAARCHS or "
+            "-DCMAKE_CUDA_ARCHITECTURES=...\n"
+            "  architectures: ${_architectures}")
+    endif()
+
+    message(STATUS
+        "KegAlign: building for ${_count} CUDA architectures, from ${_source}")
+    set(${out_var} "${_architectures}" PARENT_SCOPE)
+endfunction()

--- a/tests/stub-arches.bash
+++ b/tests/stub-arches.bash
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Stands in for get-cuda-arches.bash so the tests never need nvcc.
+echo -n "75-real;80-real;86"

--- a/tests/test_cuda_architectures.cmake
+++ b/tests/test_cuda_architectures.cmake
@@ -1,0 +1,116 @@
+# Tests for kegalign_select_cuda_architectures().
+#
+# Run with:  cmake -P tests/test_cuda_architectures.cmake
+#
+# No compiler, no CUDA toolkit and no GPU are needed: the function is pure list
+# handling plus one execute_process, and the tests substitute a stub for that.
+
+cmake_minimum_required(VERSION 3.10)
+
+get_filename_component(_repo "${CMAKE_CURRENT_LIST_DIR}/.." ABSOLUTE)
+include("${_repo}/cmake/SelectCudaArchitectures.cmake")
+
+set(_failures 0)
+
+function(expect_eq label actual expected)
+  if(NOT "${actual}" STREQUAL "${expected}")
+    message("not ok - ${label}\n     got: [${actual}]\nexpected: [${expected}]")
+    math(EXPR _failures "${_failures} + 1")
+    set(_failures "${_failures}" PARENT_SCOPE)
+  else()
+    message("ok - ${label}")
+  endif()
+endfunction()
+
+# A stub standing in for get-cuda-arches.bash, so the tests never invoke nvcc.
+set(_stub "${CMAKE_CURRENT_LIST_DIR}/stub-arches.bash")
+
+# ---------------------------------------------------------------------------
+# The bug this all exists for: conda-forge exports CUDAARCHS, and KegAlign used
+# to overwrite it unconditionally with its own longer list. That list then blew
+# past what CCCL's namespace macro can expand, and Thrust failed to compile.
+# An architecture list supplied by the environment must win.
+# ---------------------------------------------------------------------------
+set(ENV{CUDAARCHS} "50-real;52-real;90a-real;121-virtual")
+unset(CMAKE_CUDA_ARCHITECTURES)
+kegalign_select_cuda_architectures(got SCRIPT "${_stub}")
+expect_eq("CUDAARCHS from the environment is used verbatim"
+          "${got}" "50-real;52-real;90a-real;121-virtual")
+
+# An explicit caller choice (-DCMAKE_CUDA_ARCHITECTURES=... or a toolchain
+# file) outranks even CUDAARCHS.
+set(ENV{CUDAARCHS} "50-real;52-real")
+set(CMAKE_CUDA_ARCHITECTURES "80-real;90")
+kegalign_select_cuda_architectures(got SCRIPT "${_stub}")
+expect_eq("an explicit CMAKE_CUDA_ARCHITECTURES outranks CUDAARCHS"
+          "${got}" "80-real;90")
+unset(CMAKE_CUDA_ARCHITECTURES)
+
+# With nothing supplied, fall back to asking nvcc.
+unset(ENV{CUDAARCHS})
+kegalign_select_cuda_architectures(got SCRIPT "${_stub}")
+expect_eq("falls back to the script when nothing is supplied"
+          "${got}" "75-real;80-real;86")
+
+# An empty CUDAARCHS is not a choice; it must not shadow the fallback.
+set(ENV{CUDAARCHS} "")
+kegalign_select_cuda_architectures(got SCRIPT "${_stub}")
+expect_eq("an empty CUDAARCHS falls through to the script"
+          "${got}" "75-real;80-real;86")
+unset(ENV{CUDAARCHS})
+
+# ---------------------------------------------------------------------------
+# Counting, which is what actually decides whether the build survives. CCCL
+# expands THRUST_NAMESPACE_BEGIN as
+#     _CCCL_PP_SPLICE_WITH(_, THRUST, THRUST_VERSION, SM, __CUDA_ARCH_LIST__, NS)
+# so the argument count is 4 + (distinct architectures). Measured against the
+# 12.9.27 headers with cpp alone: <=15 architectures expand correctly, 16 is
+# silently garbled, 17-26 is a hard error, >=27 is silently garbled again.
+# -real/-virtual suffixes and the a/f variants all collapse to one architecture.
+# ---------------------------------------------------------------------------
+kegalign_count_cuda_architectures(n "50-real;52-real;90a-real;90-real;121-virtual;121")
+expect_eq("suffixes and a/f variants collapse to distinct architectures" "${n}" "4")
+
+kegalign_count_cuda_architectures(n "100f-real;100a-real;100")
+expect_eq("f and a variants of one architecture count once" "${n}" "1")
+
+# conda-forge's own CUDA 12.9 list -- 14, which is why those builds were green.
+kegalign_count_cuda_architectures(n
+  "50-real;52-real;60-real;61-real;70-real;75-real;80-real;86-real;89-real;90a-real;100f-real;103f-real;120a-real;121f-real;121-virtual")
+expect_eq("conda-forge's 12.9 list is 14 architectures" "${n}" "14")
+
+# What get-cuda-arches.bash produces for 12.9 -- 19, over the cliff.
+kegalign_count_cuda_architectures(n
+  "50-real;52-real;53-real;60-real;61-real;62-real;70-real;72-real;75-real;80-real;86-real;87-real;89-real;90-real;100-real;101-real;103-real;120-real;121")
+expect_eq("get-cuda-arches.bash's 12.9 list is 19 architectures" "${n}" "19")
+
+# The limit itself, so a future toolkit that adds architectures trips this test
+# rather than the CI build.
+expect_eq("the documented safe limit is 15" "${KEGALIGN_CCCL_MAX_ARCHITECTURES}" "15")
+
+# ---------------------------------------------------------------------------
+# The guard must actually stop the build. Run it in a child cmake, since it
+# reports the problem with FATAL_ERROR.
+# ---------------------------------------------------------------------------
+set(_over "${CMAKE_CURRENT_LIST_DIR}/over-limit.cmake")
+file(WRITE "${_over}"
+"include(\"${_repo}/cmake/SelectCudaArchitectures.cmake\")\n"
+"set(CMAKE_CUDA_ARCHITECTURES \"50;52;53;60;61;62;70;72;75;80;86;87;89;90;100;101;103;120;121\")\n"
+"kegalign_select_cuda_architectures(got)\n")
+execute_process(COMMAND "${CMAKE_COMMAND}" -P "${_over}"
+                RESULT_VARIABLE _rc ERROR_VARIABLE _err OUTPUT_QUIET)
+file(REMOVE "${_over}")
+if(_rc EQUAL 0)
+  message("not ok - 19 architectures must be refused, but configure succeeded")
+  math(EXPR _failures "${_failures} + 1")
+elseif(NOT _err MATCHES "19 CUDA architectures")
+  message("not ok - refusal did not name the count\n  got: ${_err}")
+  math(EXPR _failures "${_failures} + 1")
+else()
+  message("ok - 19 architectures is refused with a legible message")
+endif()
+
+if(_failures GREATER 0)
+  message(FATAL_ERROR "${_failures} test(s) failed")
+endif()
+message("\nall tests passed")


### PR DESCRIPTION
Fixes the CUDA 12.9 build, which #39 broke, and removes the reason it could break.

### What went wrong

#39 raised `cmake_minimum_required` 3.10 → 3.30, on my argument that
`cmake_policy(SET CMP0167 NEW)` required it. That argument was wrong — setting
an unknown policy is an error on the CMake that is *running*, which has nothing
to do with the declared floor.

Raising the floor flipped which CUDA architecture list wins. conda-forge exports
`CUDAARCHS` (14 architectures); `CMakeLists.txt` overwrote it with
`get-cuda-arches.bash` output (19). At a 3.10 floor the overwrite never took
effect, so **every shipped package has used conda-forge's list and ignored ours**
— 0.1.2.10 and 0.1.2.11 record the identical 14 in `__CUDA_ARCH_LIST__`. At 3.30
ours finally won, and ours does not compile.

CCCL opens Thrust's ABI namespace as

```c
inline namespace _CCCL_PP_SPLICE_WITH(_, THRUST, THRUST_VERSION, SM, __CUDA_ARCH_LIST__, NS)
```

so the argument count is `4 + (distinct architectures)`, and CCCL's counter does
not survive arbitrary widths. Measured against the 12.9.27 headers with the
preprocessor alone — no GPU, no toolkit:

| architectures | result |
|---|---|
| ≤ 15 | correct |
| 16 | **silently expands to the wrong namespace** |
| 17 – 26 | hard error (this bug) |
| ≥ 27 | silently wrong again |

12.9 gives 19 — the failing band. conda-forge's 14 is just inside, which is the
only reason this ever worked. CUDA 13.x gives 12 and is unaffected.

### Isolation

Each of #39's three changes tested separately against the feedstock's 12.9 job:

```
floor 3.30 + c++17 + CUDA_STANDARD 17 + REQUIRED   FAIL   (feedstock #17)
floor 3.30 + c++14 + CUDA_STANDARD 14 + REQUIRED   FAIL   (feedstock #18)
floor 3.10 + c++17 + CUDA_STANDARD 17 + REQUIRED   GREEN  (feedstock #19)
```

The C++17 switch — the actual point of #39, and what CUDA 13 needs — is not
implicated and is kept, along with `CUDA_STANDARD_REQUIRED ON`. A diagnostic run
(feedstock #20) then confirmed the mechanism directly: `CUDAARCHS` carried 14,
our script produced 19, and 19 `-gencode` flags reached nvcc.

### The change

**`bf174d2`** — guard each `cmake_policy(SET ...)` with `if(POLICY ...)`, restore
the 3.10 floor. Fixes the regression on its own.

**`e5a7ee1`** — establish explicit precedence (caller → `CUDAARCHS` → script) so
a supplied list is never overwritten, and check the count so an over-wide list
fails with a named error instead of inside CCCL. The 16 case is the one that
most needs this: no error today, just a binary whose Thrust symbols are in a
namespace nobody meant.

### Tests

Written before the fix, and needing no compiler or CUDA toolkit:

```
cmake -P tests/test_cuda_architectures.cmake
```

Ten cases: precedence order, counting (`-real`/`-virtual` and the `a`/`f`
variants collapse to one architecture each), both real-world lists, and that the
guard actually refuses 19.

### Two things worth saying plainly

- **A hand build on CUDA 12.9 with no `CUDAARCHS` has never worked** — 19
  architectures were always over the limit. This makes it say so instead of
  failing inside someone else's headers.
- **#38 fixed nothing that ships.** It corrected drift in a value no packaged
  build consumed, and it drops the `a`/`f` variants that conda-forge's list
  deliberately uses.

There is also an upstream CCCL bug here — silent misexpansion at 16 and ≥27
rather than a diagnostic — worth reporting separately with the reproducer.
