### PR TITLE
Size the seed buffer for the seed pattern actually in use

### DIFF
--- a/common/ntcoding.cpp
+++ b/common/ntcoding.cpp
@@ -6,6 +6,7 @@
 int shape_pos[32];
 int shape_size;
 int transition_pos[32];
+int num_transitions;
 
 inline uint32_t NtChar2Int (char nt) {
     switch(nt) {
@@ -20,12 +21,14 @@ inline uint32_t NtChar2Int (char nt) {
 
 int GenerateShapePos (std::string shape) {
     shape_size = 0;
+    num_transitions = 0;
     int j = 0;
     for (int i = 0; i < shape.length(); i++) {
         if ((shape[i] == '1') || (shape[i] == 'T')) {
             shape_pos[shape_size++] = i;
             if (shape[i] == 'T') {
                 transition_pos[j] = 1;
+                num_transitions++;
             }
             else {
                 transition_pos[j] = 0;
@@ -38,6 +41,12 @@ int GenerateShapePos (std::string shape) {
 
 int IsTransitionAtPos(int t) {
     return transition_pos[t];
+}
+
+// How many positions in the current seed pattern allow a transition.  This is
+// what bounds the size of a seed_offset_vector, so MaxSeedsPerChunk() needs it.
+int GetNumTransitions() {
+    return num_transitions;
 }
 
 uint32_t GetKmerIndexAtPos (char* sequence, size_t pos, uint32_t seed_size) {

--- a/common/ntcoding.h
+++ b/common/ntcoding.h
@@ -6,6 +6,7 @@
 uint32_t NtChar2Int (char nt);
 int GenerateShapePos(std::string shape);
 int IsTransitionAtPos(int t);
+int GetNumTransitions();
 uint32_t GetKmerIndexAtPos(char* sequence, size_t pos, uint32_t seed_size);
 void RevComp(char* dst_buffer, char* src_buffer, size_t rc_start, size_t start, size_t len);
 void GenerateSeedPosTable(char* ref_str, size_t start_addr, uint32_t ref_length, uint32_t step, int shape_size, int kmer_size);

--- a/common/seed_capacity.h
+++ b/common/seed_capacity.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <stdint.h>
+
+// The largest number of seeds a single call to SeedAndFilter() can be handed,
+// and therefore the size that d_seed_offsets (and d_hit_num_vec) must be
+// allocated to on the GPU.
+//
+// src/seeder.cpp walks at most wga_chunk_size query positions per call, and for
+// each position whose k-mer is valid it pushes one seed for the position itself
+// plus one more for every position in the seed pattern at which a transition is
+// allowed.  This function has to stay in step with that loop; tests/ pins the
+// two together.
+static inline uint64_t MaxSeedsPerChunk(bool transition, uint32_t num_transitions, uint32_t wga_chunk_size)
+{
+    if (!transition) {
+        return (uint64_t) wga_chunk_size;
+    }
+
+    return (1ULL + num_transitions) * wga_chunk_size;
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -327,7 +327,7 @@ int main(int argc, char** argv){
     fprintf(stderr, "Using %d threads\n", cfg.num_threads);
 
     cfg.num_gpu = g_InitializeInterface (cfg.num_gpu);
-    g_InitializeProcessor (cfg.seed.transition, cfg.wga_chunk_size, cfg.seed.size, cfg.sub_mat, cfg.xdrop, cfg.hspthresh, cfg.noentropy);
+    g_InitializeProcessor (cfg.seed.transition, GetNumTransitions(), cfg.wga_chunk_size, cfg.seed.size, cfg.sub_mat, cfg.xdrop, cfg.hspthresh, cfg.noentropy);
 
     ref_DRAM = new DRAM;
     query_DRAM = new DRAM;

--- a/src/seed_filter.cu
+++ b/src/seed_filter.cu
@@ -5,8 +5,10 @@
 #include <thrust/scan.h>
 #include <thrust/unique.h>
 #include <thrust/sort.h>
+#include <stdlib.h>
 #include "cuda_utils.h"
 #include "parameters.h"
+#include "seed_capacity.h"
 #include "seed_filter.h"
 #include "seed_filter_interface.h"
 #include "store.h"
@@ -18,7 +20,7 @@
 
 #define MAX_HITS_PER_GB 4194304
 
-int MAX_SEEDS;
+int64_t MAX_SEEDS;
 int MAX_HITS;
 
 uint32_t seed_size;
@@ -686,7 +688,12 @@ std::vector<segmentPair> SeedAndFilter (std::vector<uint64_t> seed_offset_vector
     uint32_t total_anchors = 0;
 
     uint32_t num_seeds = seed_offset_vector.size();
-    assert(num_seeds <= MAX_SEEDS);
+    // Not an assert: Release builds define NDEBUG and delete it, which is how a
+    // buffer overrun reached cudaMemcpy() as a bare " invalid argument " instead.
+    if (num_seeds > (uint64_t) MAX_SEEDS) {
+        fprintf(stderr, "Error: %u seeds in one chunk exceeds the seed buffer capacity of %ld\n", num_seeds, MAX_SEEDS);
+        exit(15);
+    }
 
     uint64_t* tmp_offset = (uint64_t*) malloc(num_seeds*sizeof(uint64_t));
     for (uint32_t i = 0; i < num_seeds; i++) {
@@ -808,16 +815,13 @@ std::vector<segmentPair> SeedAndFilter (std::vector<uint64_t> seed_offset_vector
     return gpu_filter_output;
 }
 
-void InitializeProcessor (bool transition, uint32_t WGA_CHUNK, uint32_t input_seed_size, int* sub_mat, int input_xdrop, int input_hspthresh, bool input_noentropy){
+void InitializeProcessor (bool transition, uint32_t num_transitions, uint32_t WGA_CHUNK, uint32_t input_seed_size, int* sub_mat, int input_xdrop, int input_hspthresh, bool input_noentropy){
 
     cudaDeviceProp deviceProp;
     cudaGetDeviceProperties(&deviceProp, 0);
     float global_mem_gb = static_cast<float>(deviceProp.totalGlobalMem / 1073741824.0f);
 
-    if(transition)
-        MAX_SEEDS = 13*WGA_CHUNK;
-    else
-        MAX_SEEDS = WGA_CHUNK;
+    MAX_SEEDS = MaxSeedsPerChunk(transition, num_transitions, WGA_CHUNK);
 
     MAX_HITS = MAX_HITS_PER_GB*global_mem_gb;
 

--- a/src/seed_filter.h
+++ b/src/seed_filter.h
@@ -1,7 +1,7 @@
 #include <vector>
 #include "graph.h"
 
-typedef void(*InitializeProcessor_ptr)(bool transition, uint32_t WGA_CHUNK, uint32_t input_seed_size, int* sub_mat, int input_xdrop, int input_hspthresh, bool input_noentropy);
+typedef void(*InitializeProcessor_ptr)(bool transition, uint32_t num_transitions, uint32_t WGA_CHUNK, uint32_t input_seed_size, int* sub_mat, int input_xdrop, int input_hspthresh, bool input_noentropy);
 typedef void(*SendQueryWriteRequest_ptr)(size_t addr, uint32_t len, uint32_t buffer);
 typedef std::vector<segmentPair> (*SeedAndFilter_ptr)(std::vector<uint64_t> seed_offset_vector, bool rev, uint32_t buffer);
 typedef void(*ClearQuery_ptr)(uint32_t buffer);

--- a/tests/test_seed_capacity.bash
+++ b/tests/test_seed_capacity.bash
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Builds and runs tests/test_seed_capacity.cpp against the real common/ntcoding.cpp.
+# No CUDA toolkit and no GPU are needed.
+set -o errexit -o nounset -o pipefail
+
+repo="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+"${CXX:-c++}" -std=c++17 -Wall -I "$repo/common" \
+    -o "$tmp/test_seed_capacity" \
+    "$repo/tests/test_seed_capacity.cpp" \
+    "$repo/common/ntcoding.cpp"
+
+"$tmp/test_seed_capacity"

--- a/tests/test_seed_capacity.cpp
+++ b/tests/test_seed_capacity.cpp
@@ -1,0 +1,133 @@
+// Tests that the GPU seed buffer is sized for the seed pattern actually in use.
+//
+// Run with:  bash tests/test_seed_capacity.bash
+//
+// Needs a C++ compiler, but no CUDA toolkit and no GPU: the rule under test is
+// MaxSeedsPerChunk(), which is pure arithmetic, and the transition counting is
+// done by the real common/ntcoding.cpp.
+//
+// ---------------------------------------------------------------------------
+// The bug this all exists for: MAX_SEEDS was a hardcoded 13*wga_chunk_size,
+// where 13 is 1 + the 12 transition positions of the DEFAULT 12of19 seed. The
+// 14of22 seed has 14 transition positions and so emits 15 seeds per query
+// position, overrunning d_seed_offsets. On a real usegalaxy.org run this
+// surfaced as
+//
+//     Error: cudaMemcpy of 26650680 bytes for seed_offsets failed
+//            with error " invalid argument "
+//
+// 26650680/8 = 3331335 seeds copied into a buffer sized for 3250000. The
+// assert() that should have caught it is compiled out by NDEBUG in the Release
+// builds conda-forge and Galaxy ship.
+// ---------------------------------------------------------------------------
+
+#include <stdio.h>
+#include <stdint.h>
+#include <string>
+
+#include "ntcoding.h"
+#include "seed_capacity.h"
+
+static int failures = 0;
+
+static void expect_eq(const char* label, uint64_t actual, uint64_t expected)
+{
+    if (actual != expected) {
+        printf("not ok - %s\n     got: %lu\nexpected: %lu\n", label, actual, expected);
+        failures++;
+    } else {
+        printf("ok - %s\n", label);
+    }
+}
+
+static void expect_at_least(const char* label, uint64_t actual, uint64_t floor)
+{
+    if (actual < floor) {
+        printf("not ok - %s\n     got: %lu\nexpected at least: %lu (short by %lu)\n",
+               label, actual, floor, floor - actual);
+        failures++;
+    } else {
+        printf("ok - %s\n", label);
+    }
+}
+
+// Mirrors the push sequence in src/seeder.cpp: for a query position whose k-mer
+// is valid, one seed for the position itself, then one more for each position in
+// the pattern at which a transition is allowed.  Uses the real IsTransitionAtPos()
+// so that a change to the seed parser shows up here.
+static uint64_t SeedsPushedPerPosition(int kmer_size)
+{
+    uint64_t pushed = 1;
+    for (int t = 0; t < kmer_size; t++) {
+        if (IsTransitionAtPos(t) == 1) {
+            pushed++;
+        }
+    }
+    return pushed;
+}
+
+// The seeder hands SeedAndFilter() at most wga_chunk_size positions at a time.
+static uint64_t WorstCaseSeedsInOneChunk(const std::string& shape, uint32_t wga_chunk_size)
+{
+    int kmer_size = GenerateShapePos(shape);
+    return SeedsPushedPerPosition(kmer_size) * wga_chunk_size;
+}
+
+// main.cpp normalises a user's pattern so every match position becomes 'T'
+// before calling GenerateShapePos(), so these are the shapes as the parser sees them.
+static const char* SEED_12of19 = "TTT0T00TT00T0T0TTTT";
+static const char* SEED_14of22 = "TTT0T0TT00TT00T0T0TTTT";
+
+int main()
+{
+    const uint32_t chunk = 250000;   // DEFAULT_WGA_CHUNK, and the failing job's value
+
+    // --- the default seed must be unaffected -------------------------------
+    GenerateShapePos(SEED_12of19);
+    expect_eq("12of19 has 12 transition positions", GetNumTransitions(), 12);
+    expect_eq("12of19 capacity is unchanged at 13*chunk",
+              MaxSeedsPerChunk(true, GetNumTransitions(), chunk), 13ULL * chunk);
+    expect_at_least("12of19 capacity covers what the seeder pushes",
+                    MaxSeedsPerChunk(true, GetNumTransitions(), chunk),
+                    WorstCaseSeedsInOneChunk(SEED_12of19, chunk));
+
+    // --- the bug -----------------------------------------------------------
+    GenerateShapePos(SEED_14of22);
+    expect_eq("14of22 has 14 transition positions", GetNumTransitions(), 14);
+    expect_at_least("14of22 capacity covers what the seeder pushes",
+                    MaxSeedsPerChunk(true, GetNumTransitions(), chunk),
+                    WorstCaseSeedsInOneChunk(SEED_14of22, chunk));
+
+    // The seed count from the job that actually died.
+    GenerateShapePos(SEED_14of22);
+    expect_at_least("14of22 capacity covers the 3331335 seeds of the failing run",
+                    MaxSeedsPerChunk(true, GetNumTransitions(), chunk), 3331335);
+
+    // --- sized by transitions, not by weight -------------------------------
+    // Mixed pattern: '1' is a match position that does NOT allow a transition,
+    // so weight is 12 but only 11 transitions -> 12 seeds per position. A fix
+    // that reached for kmer_size instead of the transition count would over-allocate.
+    const char* mixed = "TTT0T00TT00T0T0TT1T";
+    GenerateShapePos(mixed);
+    expect_eq("mixed pattern: weight 12 but only 11 transitions", GetNumTransitions(), 11);
+    expect_eq("mixed pattern capacity follows transitions, not weight",
+              MaxSeedsPerChunk(true, GetNumTransitions(), chunk),
+              WorstCaseSeedsInOneChunk(mixed, chunk));
+
+    // --- the count must not carry over between patterns ---------------------
+    GenerateShapePos(SEED_14of22);
+    GenerateShapePos(SEED_12of19);
+    expect_eq("GenerateShapePos resets the transition count", GetNumTransitions(), 12);
+
+    // --- --notransition path ------------------------------------------------
+    GenerateShapePos(SEED_14of22);
+    expect_eq("notransition gives one seed per position",
+              MaxSeedsPerChunk(false, GetNumTransitions(), chunk), chunk);
+
+    if (failures > 0) {
+        printf("\n%d test(s) failed\n", failures);
+        return 1;
+    }
+    printf("\nall tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
  `MAX_SEEDS` is a hardcoded `13*wga_chunk_size`. That `13` is `1 +` the 12 transition positions of the **default** `12of19` seed, so
  it fits that one pattern exactly and nothing else.

  `src/seeder.cpp` pushes one seed per query position plus one for every transition position in the pattern. `14of22` has 14
  transition positions, so it emits **15** seeds per position and overruns `d_seed_offsets`.

  ## Reproducing

  A `14of22` run on usegalaxy.org (kegalign `0.2.1.13+galaxy1`, `wga_chunk_size` 250000, transitions on) died with:

  ```
  Error: cudaMemcpy of 26650680 bytes for seed_offsets failed with error " invalid argument "
  terminate called after throwing an instance of 'thrust::...::system_error'
    what():  CUDA free failed: cudaErrorCudartUnloading: driver shutting down
  ```

  26650680/8 = **3331335** seeds copied into a buffer sized for **3250000** — 81335 seeds past the end.

  | seed | seeds/position | needs | allocated |
  |---|---|---|---|
  | `12of19` | 13 | 3,250,000 | 3,250,000 — exact fit, zero margin |
  | `14of22` | 15 | 3,750,000 | 3,250,000 — 500,000 short |

  Two things make this harder to spot than it should be:

  * **The `assert` is compiled out.** `assert(num_seeds <= MAX_SEEDS)` in `SeedAndFilter()` is the right check, but conda-forge
  builds with `-DCMAKE_BUILD_TYPE=Release`, which defines `NDEBUG`. Every released build has no guard, so the overrun surfaces as a
  bare `" invalid argument "` from `cudaMemcpy` instead.
  * **The thrust message and the `-6` exit are a cascade, not a second fault.** `check_cuda_memcpy` calls `exit()`, which runs the
  global `thrust::device_vector` destructors after the CUDA runtime has begun unloading; they throw from a destructor and
  `std::terminate` fires. Only the `cudaMemcpy` line is the real error.

  It is also data-dependent, which is why it can run for a long time first: `NtChar2Int()` accepts only uppercase `ACGT` and maps
  everything else — lowercase included — to `N_NT`, so soft-masked positions yield no seeds. Only a chunk that is more than 86.7%
  unmasked can overflow. The failing chunk was 88.8%.

  **No completed run is silently wrong.** `d_hit_num_vec` is also sized `MAX_SEEDS` and indexed by `num_seeds`, so it would overrun
  at the same threshold — but the `cudaMemcpy` is the first use and exits before any kernel launches. Affected runs die loudly.

  This dates to 411b892 (July 2020) and is present in SegAlign too.

  ## The fix

  The bound now follows the pattern instead of a constant:

  ```c
  return (1ULL + num_transitions) * wga_chunk_size;
  ```

  * For `12of19` this evaluates to exactly `13*wga_chunk_size`, so **the default path is unchanged**.
  * For `14of22` it is `15*wga_chunk_size` — about 6 MB more per GPU across `d_seed_offsets` and `d_hit_num_vec`.
  * It is driven by the **transition count**, not the seed weight, because a `'1'` in a pattern is a match position that does not
  permit a transition. `main.cpp` currently normalises every match position to `'T'` before parsing, so the two are equal in practice
  today; the test pins the correct one so that stays true if the normalisation changes.

  The rule moves to `common/seed_capacity.h` so it can be tested without a CUDA toolkit or a GPU — it was previously a literal inside
  a `.cu` file, which is a large part of why it went unnoticed. `MAX_SEEDS` widens to `int64_t` to take the `uint64_t` result
  without narrowing, and the `assert` becomes a check that survives `NDEBUG`.

  ## Tests

  `tests/test_seed_capacity.bash` follows the pattern of the existing `tests/test_cuda_architectures.cmake`: self-contained, no CUDA
  toolkit and no GPU. It links the real `common/ntcoding.cpp`, so it exercises the actual shape parser and `IsTransitionAtPos()`
  rather than a copy of them, and derives the demand side from a loop mirroring `seeder.cpp`.

  Against the unfixed rule it fails with the numbers from the run above:

  ```
  not ok - 14of22 capacity covers what the seeder pushes
               got: 3250000   expected at least: 3750000 (short by 500000)
  not ok - 14of22 capacity covers the 3331335 seeds of the failing run
               got: 3250000   expected at least: 3331335 (short by 81335)
  ```

  After the change all 10 checks pass, including a guard that `12of19` still comes out at exactly `13*wga_chunk_size`.
  `tests/test_cuda_architectures.cmake` still passes.

  ## What I have not verified

  **`src/seed_filter.cu` has not yet been compiled with these edits.** The host-side test passes and the arithmetic is pinned, but
  the `.cu` changes are reviewed rather than built, and no `14of22` alignment has been run against the patched binary yet. I'll
  follow up on this PR once I've done a build and one `14of22` run — worth having that before merging.
  
    Follow-up as promised. Built and run on a 4× A100-SXM4-80GB host, using the conda-forge builds of both versions, with identical input and command.
  
  **kegalign 0.2.1.13** — aborts inside reference block 0:
  
  ```
  Error: cudaMemcpy of 26458320 bytes for seed_offsets failed with error " invalid argument "
  exit 134   (SIGABRT)
  ```
  
  **kegalign 0.2.2.14** (this fix) — completes:
  
  ```
  exit 0
  ```

  Command in both cases:

  ```
  kegalign target.fa query.fa work/ --seed 14of22 --strand both --num_threads 32
  ```

  The fixed build is not exiting early. It finishes reference block 0, then goes on to process reference block 1 to completion — 178 interval dispatches in
  total — and emits 356 LASTZ commands. It covers everything past the point where 0.2.1.13 aborted.

  Inputs were the pair from the usegalaxy.org job that first reported this: two WindowMasker-softmasked *Cannabis sativa* assemblies, ~919 MB and ~891 MB.

  ### The arithmetic confirms the cause, not just the symptom

  `26458320 / 8` = **3,307,290** seeds copied into the 3,250,000-seed buffer, an overrun of 57,290. That is **13.229 seeds per query position**; the
  original usegalaxy.org report was **13.325**.

  Both sit strictly between 13 and 15. `12of19` emits at most 13 seeds per position, so neither figure is reachable under it; `14of22` emits up to 15. Two
  independent runs on different hardware, both landing in that band, is the seed pattern being confirmed as the cause rather than an error string happening
  to match.

  The two runs differ in byte count because which chunk overflows first is data- and scheduling-dependent — 1 GPU on usegalaxy.org versus 4 here. The
  mechanism is identical, and `exit 134` is `128 + 6`, the same `SIGABRT` behind the `returncode -6` in the original report.
  
  ### Note for anyone reproducing
  
  `#seeds`, `#seed hits` and `#HSPs` are inside `if(cfg.debug)`, so they print only with `--debug`. Reproducing the overflow also needs a query with a 250
  kb chunk that is more than ~86.7% uppercase ACGT, since soft-masked bases yield no seeds at all — a heavily masked assembly will not trip it.