### PR TITLE
Honour bad_score and fill_score from a LASTZ scoring file

### DIFF
--- a/common/scoring.c
+++ b/common/scoring.c
@@ -1,11 +1,62 @@
+#include <string.h>
+
 #include "scoring.h"
 
-void load_scoring_matrix(int scoring_matrix[][L_NT], char* scoreFilename) {
+// LASTZ's own defaults, from the score set file format documented in
+// dna_utilities.c: bad_score is the score for the row and column of the "bad"
+// character (X, for DNA), fill_score is used for any pair the matrix does not
+// define.
+#define DEFAULT_BAD_SCORE  -1000
+#define DEFAULT_FILL_SCORE  -100
+
+static int in_uchars(const u8* s, int ch) {
+	for (; *s != 0; s++) {
+		if ((int) *s == ch) {
+			return 1;
+		}
+	}
+	return 0;
+}
+
+// LASTZ stores bad_score by writing it across the row and column of the bad
+// character (X, for DNA), rather than keeping the scalar.
+static int recover_bad_score(scoreset* ss) {
+	if (ss->badRow == 0 || ss->badCol == 0) {
+		return DEFAULT_BAD_SCORE;
+	}
+	return (int) ss->sub[ss->badRow][ss->badCol];
+}
+
+// LASTZ fills all 256x256 entries with fill_score and then writes the matrix,
+// the lower case copies and the bad row/column over the top, so any pair it
+// never touched still holds fill_score.
+static int recover_fill_score(scoreset* ss) {
+	int r, c;
+
+	for (r = 1; r < 256; r++) {
+		if (r == ss->badRow || in_uchars(ss->rowChars, r)) {
+			continue;
+		}
+		for (c = 1; c < 256; c++) {
+			if (c == ss->badCol || in_uchars(ss->colChars, c)) {
+				continue;
+			}
+			return (int) ss->sub[r][c];
+		}
+	}
+
+	return DEFAULT_FILL_SCORE;
+}
+
+void load_scoring_matrix(int scoring_matrix[][L_NT], int* bad_score, int* fill_score, char* scoreFilename) {
 	exscoreset*     xss = NULL;
 	u8*             rowChars = (u8*)"ACGT";
 	u8*             colChars = (u8*)"ACGT";
 	u8*             r, *c;
 	int             x, y;
+
+	*bad_score  = DEFAULT_BAD_SCORE;
+	*fill_score = DEFAULT_FILL_SCORE;
 
 	xss = read_score_set_by_name (scoreFilename);
 
@@ -15,8 +66,73 @@ void load_scoring_matrix(int scoring_matrix[][L_NT], char* scoreFilename) {
 		}
 	}
 
+	*bad_score  = recover_bad_score((scoreset*) xss);
+	*fill_score = recover_fill_score((scoreset*) xss);
+
 	if (xss != NULL) {
 		free_if_valid("score set", xss);
 		xss = NULL;
 	}
+}
+
+void build_substitution_matrix(int* sub_mat, int scoring_matrix[][L_NT], int bad_score, int fill_score, const char* ambiguous_field, int ambiguous_reward, int ambiguous_penalty, int xdrop) {
+	int i, j;
+
+	//ACGT
+	for(i = 0; i < L_NT; i++){
+		for(j = 0; j < L_NT; j++){
+			sub_mat[i*NUC+j] = scoring_matrix[i][j];
+		}
+	}
+
+	//lower case characters
+	for(i = 0; i < L_NT; i++){
+		sub_mat[i*NUC+L_NT] = bad_score;
+		sub_mat[L_NT*NUC+i] = bad_score;
+	}
+	sub_mat[L_NT*NUC+L_NT] = bad_score;
+
+	//N
+	if(strcmp(ambiguous_field, "n") == 0 || strcmp(ambiguous_field, "iupac") == 0){
+		for(i = 0; i < N_NT; i++){
+			sub_mat[i*NUC+N_NT] = ambiguous_penalty;
+			sub_mat[N_NT*NUC+i] = ambiguous_penalty;
+		}
+		sub_mat[N_NT*NUC+N_NT] = ambiguous_reward;
+	}
+	else{
+		for(i = 0; i < N_NT; i++){
+			sub_mat[i*NUC+N_NT] = bad_score;
+			sub_mat[N_NT*NUC+i] = bad_score;
+		}
+		sub_mat[N_NT*NUC+N_NT] = bad_score;
+	}
+
+	//other IUPAC
+	if(strcmp(ambiguous_field, "iupac") == 0){
+		for(i = 0; i < X_NT; i++){
+			sub_mat[i*NUC+X_NT] = ambiguous_penalty;
+			sub_mat[X_NT*NUC+i] = ambiguous_penalty;
+		}
+		sub_mat[X_NT*NUC+X_NT] = ambiguous_reward;
+	}
+	else{
+		for(i = 0; i < L_NT; i++){
+			sub_mat[i*NUC+X_NT] = fill_score;
+			sub_mat[X_NT*NUC+i] = fill_score;
+		}
+
+		for(i = L_NT; i < X_NT; i++){
+			sub_mat[i*NUC+X_NT] = bad_score;
+			sub_mat[X_NT*NUC+i] = bad_score;
+		}
+		sub_mat[X_NT*NUC+X_NT] = fill_score;
+	}
+
+	//block separator
+	for(i = 0; i < E_NT; i++){
+		sub_mat[i*NUC+E_NT] = -10*xdrop;
+		sub_mat[E_NT*NUC+i] = -10*xdrop;
+	}
+	sub_mat[E_NT*NUC+E_NT] = -10*xdrop;
 }

--- a/common/scoring.h
+++ b/common/scoring.h
@@ -8,8 +8,15 @@ extern "C" {
 #include "dna_utilities.h"
 #include "parameters.h"
 
-void load_scoring_matrix(int scoring_matrix[][L_NT], char* scoreFilename);
+// Read the ACGT substitution matrix from a LASTZ scoring file, along with the
+// bad_score and fill_score settings the same file may carry.
+void load_scoring_matrix(int scoring_matrix[][L_NT], int* bad_score, int* fill_score, char* scoreFilename);
 
+// Expand the 4x4 ACGT matrix into the NUC x NUC table the GPU scores against,
+// filling in the rows for lower case, N, other IUPAC codes and the block
+// separator.  ambiguous_field is "x", "n" or "iupac" (the first field of
+// --ambiguous).
+void build_substitution_matrix(int* sub_mat, int scoring_matrix[][L_NT], int bad_score, int fill_score, const char* ambiguous_field, int ambiguous_reward, int ambiguous_penalty, int xdrop);
 
 #ifdef __cplusplus
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -242,64 +242,11 @@ int main(int argc, char** argv){
                                    { -123,  -31, -114,   91}};
 
     if(vm.count("scoring")) {
-        load_scoring_matrix(tmp_sub_mat, (char *) cfg.scoring_file.c_str());
+        load_scoring_matrix(tmp_sub_mat, &bad_score, &fill_score, (char *) cfg.scoring_file.c_str());
     }
 
-        for(int i = 0; i < L_NT; i++){
-            for(int j = 0; j < L_NT; j++){
-                cfg.sub_mat[i*NUC+j] = tmp_sub_mat[i][j];
-            }
-        }
-
-        //lower case characters
-        for(int i = 0; i < L_NT; i++){
-            cfg.sub_mat[i*NUC+L_NT] = bad_score;
-            cfg.sub_mat[L_NT*NUC+i] = bad_score;
-        }
-        cfg.sub_mat[L_NT*NUC+L_NT] = bad_score;
-
-        //N
-        if(ambiguous_field == "n" || ambiguous_field == "iupac"){
-            for(int i = 0; i < N_NT; i++){
-                cfg.sub_mat[i*NUC+N_NT] = ambiguous_penalty;
-                cfg.sub_mat[N_NT*NUC+i] = ambiguous_penalty;
-            }
-            cfg.sub_mat[N_NT*NUC+N_NT] = ambiguous_reward;
-        }
-        else{
-            for(int i = 0; i < N_NT; i++){
-                cfg.sub_mat[i*NUC+N_NT] = bad_score;
-                cfg.sub_mat[N_NT*NUC+i] = bad_score;
-            }
-            cfg.sub_mat[N_NT*NUC+N_NT] = bad_score;
-        }
-
-        //other IUPAC
-        if(ambiguous_field == "iupac"){
-            for(int i = 0; i < X_NT; i++){
-                cfg.sub_mat[i*NUC+X_NT] = ambiguous_penalty;
-                cfg.sub_mat[X_NT*NUC+i] = ambiguous_penalty;
-            }
-            cfg.sub_mat[X_NT*NUC+X_NT] = ambiguous_reward;
-        }
-        else{
-            for(int i = 0; i < L_NT; i++){
-                cfg.sub_mat[i*NUC+X_NT] = fill_score;
-                cfg.sub_mat[X_NT*NUC+i] = fill_score;
-            }
-
-            for(int i = L_NT; i < X_NT; i++){
-                cfg.sub_mat[i*NUC+X_NT] = bad_score;
-                cfg.sub_mat[X_NT*NUC+i] = bad_score;
-            }
-            cfg.sub_mat[X_NT*NUC+X_NT] = fill_score;
-        }
-
-        for(int i = 0; i < E_NT; i++){
-            cfg.sub_mat[i*NUC+E_NT] = -10*cfg.xdrop;
-            cfg.sub_mat[E_NT*NUC+i] = -10*cfg.xdrop;
-        }
-        cfg.sub_mat[E_NT*NUC+E_NT] = -10*cfg.xdrop;
+    build_substitution_matrix(cfg.sub_mat, tmp_sub_mat, bad_score, fill_score,
+                              ambiguous_field.c_str(), ambiguous_reward, ambiguous_penalty, cfg.xdrop);
 
     tbb::global_control global_limit(tbb::global_control::max_allowed_parallelism, cfg.num_threads);
 

--- a/tests/test_scoring.bash
+++ b/tests/test_scoring.bash
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Builds and runs tests/test_scoring.cpp against the real LASTZ score-set reader.
+# No CUDA toolkit and no GPU are needed.
+set -o errexit -o nounset -o pipefail
+
+repo="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+# A LASTZ scoring file whose every value differs from KegAlign's built-in
+# defaults, so that a value that fails to travel is visible rather than lucky.
+cat > "$tmp/scores.txt" <<'SCORES'
+# test score set - deliberately not HOXD70, and not the built-in bad/fill
+bad_score          = X:-750
+fill_score         = -55
+gap_open_penalty   =   30
+gap_extend_penalty =  400
+
+     A     C     G     T
+A   85  -110   -30  -120
+C -110    95  -125   -30
+G  -30  -125    95  -110
+T -120   -30  -110    85
+SCORES
+
+cc  -std=c11   -I "$repo/common" -c -o "$tmp/scoring.o"       "$repo/common/scoring.c"
+cc  -std=c11   -I "$repo/common" -c -o "$tmp/dna_utilities.o" "$repo/common/dna_utilities.c"
+cc  -std=c11   -I "$repo/common" -c -o "$tmp/utilities.o"     "$repo/common/utilities.c"
+c++ -std=c++17 -I "$repo/common" -c -o "$tmp/test.o"          "$repo/tests/test_scoring.cpp"
+c++ -o "$tmp/test_scoring" "$tmp/test.o" "$tmp/scoring.o" "$tmp/dna_utilities.o" "$tmp/utilities.o" -lm
+
+"$tmp/test_scoring" "$tmp/scores.txt"

--- a/tests/test_scoring.cpp
+++ b/tests/test_scoring.cpp
@@ -1,0 +1,78 @@
+// Tests that a LASTZ scoring file's bad_score and fill_score reach the
+// substitution matrix the GPU scores against.
+//
+// Run with:  bash tests/test_scoring.bash
+//
+// Needs a C++ compiler, but no CUDA toolkit and no GPU: it drives the real
+// LASTZ score-set reader in common/dna_utilities.c through common/scoring.c.
+//
+// ---------------------------------------------------------------------------
+// The bug this exists for: --scoring accepted a LASTZ scoring file but used
+// only its 4x4 ACGT block. bad_score and fill_score were parsed by the LASTZ
+// reader and then discarded, and hardcoded -1000/-100 used instead -- while
+// runner.py passes the SAME file to lastz via --scores=, where LASTZ does
+// honour them. One file, two interpretations, inside one pipeline.
+// ---------------------------------------------------------------------------
+
+#include <stdio.h>
+#include <string.h>
+
+#include "scoring.h"
+
+static int failures = 0;
+
+static void expect_eq(const char* label, int actual, int expected)
+{
+    if (actual != expected) {
+        printf("not ok - %s\n     got: %d\nexpected: %d\n", label, actual, expected);
+        failures++;
+    } else {
+        printf("ok - %s\n", label);
+    }
+}
+
+int main(int argc, char** argv)
+{
+    if (argc < 2) { fprintf(stderr, "usage: %s <scoring-file>\n", argv[0]); return 2; }
+
+    const int xdrop = 910;
+
+    // --- the default path, with no scoring file -----------------------------
+    // Pins that moving this out of main() changed nothing.
+    int hoxd70[L_NT][L_NT] = {{   91, -114,  -31, -123},
+                              { -114,  100, -125,  -31},
+                              {  -31, -125,  100, -114},
+                              { -123,  -31, -114,   91}};
+    int sub_mat[NUC*NUC];
+    build_substitution_matrix(sub_mat, hoxd70, -1000, -100, "x", -100, -100, xdrop);
+    expect_eq("default: A/A keeps the HOXD70 score",   sub_mat[A_NT*NUC+A_NT],  91);
+    expect_eq("default: lower case is bad_score",      sub_mat[A_NT*NUC+L_NT], -1000);
+    expect_eq("default: N is bad_score",               sub_mat[N_NT*NUC+A_NT], -1000);
+    expect_eq("default: other IUPAC is fill_score",    sub_mat[A_NT*NUC+X_NT], -100);
+    expect_eq("default: separator is -10*xdrop",       sub_mat[A_NT*NUC+E_NT], -9100);
+
+    // --- --ambiguous=n ------------------------------------------------------
+    build_substitution_matrix(sub_mat, hoxd70, -1000, -100, "n", 0, 0, xdrop);
+    expect_eq("ambiguous=n: N substitutions score 0",  sub_mat[N_NT*NUC+A_NT], 0);
+    expect_eq("ambiguous=n: N/N takes the reward",     sub_mat[N_NT*NUC+N_NT], 0);
+
+    // --- a scoring file carrying its own bad_score and fill_score ------------
+    int from_file[L_NT][L_NT];
+    int bad_score = 0, fill_score = 0;
+    load_scoring_matrix(from_file, &bad_score, &fill_score, argv[1]);
+
+    expect_eq("scoring file: A/A read from the file",  from_file[A_NT][A_NT],  85);
+    expect_eq("scoring file: A/C read from the file",  from_file[A_NT][C_NT], -110);
+    expect_eq("scoring file: bad_score read from the file",  bad_score,  -750);
+    expect_eq("scoring file: fill_score read from the file", fill_score,  -55);
+
+    build_substitution_matrix(sub_mat, from_file, bad_score, fill_score, "x", -100, -100, xdrop);
+    expect_eq("scoring file: lower case uses the file's bad_score",  sub_mat[A_NT*NUC+L_NT], -750);
+    expect_eq("scoring file: N uses the file's bad_score",           sub_mat[N_NT*NUC+A_NT], -750);
+    expect_eq("scoring file: other IUPAC uses the file's fill_score",sub_mat[A_NT*NUC+X_NT],  -55);
+    expect_eq("scoring file: X/X uses the file's fill_score",        sub_mat[X_NT*NUC+X_NT],  -55);
+
+    if (failures > 0) { printf("\n%d test(s) failed\n", failures); return 1; }
+    printf("\nall tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
  `--scoring` accepts a LASTZ scoring file, and `load_scoring_matrix()` reads it with LASTZ's own `read_score_set_by_name()`. But it kept only the 4×4 ACGT
  block — `bad_score` and `fill_score` were parsed, and then freed along with the rest of the score set. Hardcoded `-1000`/`-100` were used in their place.
  
  This matters because `runner.py` passes **the same file** to lastz via `--scores=`, where LASTZ *does* honour both settings. So one scoring file was being
  read two different ways inside one pipeline, and only the gapped stage was reading it as the user wrote it.
  
  Concretely, given a file containing:
  
  ```
  bad_score  = X:-750
  fill_score = -55
  ```
  
  every `bad_score` cell in the GPU's substitution matrix was `-1000` and every `fill_score` cell `-100`.
  
  ## Recovering the values
  
  LASTZ keeps neither setting as a scalar — both are expressed in the 256×256 table it builds — so both are read back out of it:
  
  * **`bad_score`** from `sub[badRow][badCol]`. LASTZ writes it across the row and column of the bad character, which is `X` for DNA.
  * **`fill_score`** from any pair the reader never wrote over. LASTZ fills all 256×256 entries with `fill_score` first, then lays the matrix, the
  lower-case copies and the bad row/column on top, so an untouched pair still holds it.
  
  If no scoring file is given, or a file leaves these out, LASTZ's own defaults (`-1000`/`-100`) still apply. **The default path is unchanged**, and the
  tests pin that.
  
  ## Why main() had to give the matrix up
  
  The substitution matrix construction was 55 lines of scoring policy inlined in `main()`, unreachable from any test — which is why nothing noticed the
  settings going missing in the first place. It moves to `build_substitution_matrix()` in `common/scoring.c`, with the `--ambiguous` mode passed in
  explicitly. No behaviour change; that is what the `default:` assertions below are for.

  ## Tests
  
  `tests/test_scoring.bash` follows the pattern of the existing `tests/test_cuda_architectures.cmake` and `tests/test_seed_capacity.bash`: self-contained,
  no CUDA toolkit and no GPU. It drives the **real** LASTZ score-set reader through a scoring file whose every value differs from the built-in defaults, so
  a value that fails to travel is visible rather than lucky, and it checks the values reach the matrix rather than only the reader.
  
  Before this change, six of its checks fail:
  
  ```
  not ok - scoring file: bad_score read from the file        got: -1000   expected: -750
  not ok - scoring file: fill_score read from the file       got:  -100   expected:  -55
  not ok - scoring file: lower case uses the file's bad_score
  not ok - scoring file: N uses the file's bad_score
  not ok - scoring file: other IUPAC uses the file's fill_score
  not ok - scoring file: X/X uses the file's fill_score
  ```
  
  The ACGT cells pass even in that state — the reader was always fine, only these two settings were dropped.
  
  After it, all 15 pass, including five `default:` checks pinning the no-scoring-file path and the `--ambiguous=n` behaviour.
  `tests/test_seed_capacity.bash` and `tests/test_cuda_architectures.cmake` still pass.
  
  ## What I have not verified
  
  `common/scoring.c` and `common/scoring.h` are genuinely compiled and exercised by the new test. The one-line call-site change in `src/main.cpp` builds
  only as part of the CUDA build, so it is reviewed rather than compiled. It needs the same build pass as #42 — one build covers both.