### PR TITLE
Run the host-side tests in CI, and tie VERSION to the tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+# Host-side checks only.
+#
+# Every suite here is deliberately buildable without a CUDA toolkit and without
+# a GPU, so it runs on a stock runner. The CUDA build itself is NOT attempted:
+# it needs nvcc and, to be worth anything, a GPU to run against. Those stay a
+# manual step before a release.
+
+name: CI
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    name: Host-side tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Seed buffer capacity follows the seed pattern
+        run: bash tests/test_seed_capacity.bash
+
+      - name: LASTZ scoring file is read in full
+        run: bash tests/test_scoring.bash
+
+      - name: CUDA architecture selection
+        run: cmake -P tests/test_cuda_architectures.cmake
+
+  version:
+    name: VERSION matches the tag
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: common/parameters.h agrees with the tag being released
+        run: bash tests/check_version.bash "${GITHUB_REF_NAME}"

--- a/common/parameters.h
+++ b/common/parameters.h
@@ -1,4 +1,4 @@
-#define VERSION "v0.1.2.8"
+#define VERSION "v0.2.2.14"
 
 #define TRANSITION_MASK 2
 #define NUC 8 

--- a/tests/check_version.bash
+++ b/tests/check_version.bash
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Checks that the VERSION define in common/parameters.h matches an expected
+# version string -- in CI, the tag being released.
+#
+# Run with:  bash tests/check_version.bash v0.2.2.14
+#
+# This exists because #define VERSION sat at v0.1.2.8 from that release all the
+# way through v0.2.1.13: five releases reported the wrong version from
+# --version and in the usage banner, because nothing tied the define to the tag.
+set -o errexit -o nounset -o pipefail
+
+if [ "$#" -ne 1 ]; then
+    echo "usage: ${0##*/} <expected-version>" >&2
+    exit 2
+fi
+
+expected="$1"
+repo="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+header="$repo/common/parameters.h"
+
+defined="$(sed -n 's/^#define VERSION "\(.*\)"$/\1/p' "$header")"
+
+if [ -z "$defined" ]; then
+    echo "not ok - no VERSION define found in $header" >&2
+    exit 1
+fi
+
+if [ "$defined" != "$expected" ]; then
+    echo "not ok - $header defines VERSION $defined, but the tag is $expected" >&2
+    exit 1
+fi
+
+echo "ok - VERSION is $defined"


### PR DESCRIPTION
There was no CI in this repository — no `.github/workflows`, and no `enable_testing()` or `add_test()` in `CMakeLists.txt`. The three test suites ran only
  when someone remembered to run them, so a green result never meant more than that a person had checked locally.
  
  ## Running the suites
  
  All three are deliberately buildable without a CUDA toolkit and without a GPU, so they run as-is on a stock `ubuntu-latest` runner with no extra setup:
  
  ```
  bash  tests/test_seed_capacity.bash            # seed buffer capacity vs the seed pattern
  bash  tests/test_scoring.bash                  # LASTZ scoring file bad_score / fill_score
  cmake -P tests/test_cuda_architectures.cmake   # CUDA architecture selection (stubs nvcc)
  ```
  
  Each exits non-zero on failure, so a break is a red check rather than a printed line nobody reads.

  **This does not attempt the CUDA build.** That needs `nvcc`, and to be worth anything it needs a GPU to run against, so it stays a manual step before a
  release. The point here is to protect the checks that *can* run everywhere, not to pretend the GPU path is covered.

  ## Tying VERSION to the tag

  This is the part that made it worth doing now. `#define VERSION` in `common/parameters.h` sat at `v0.1.2.8` from that release all the way through
  `v0.2.1.13`:

  ```
  $ git show v0.2.1.13:common/parameters.h | head -1
  #define VERSION "v0.1.2.8"
  ```

  So five releases reported the wrong version from `--version` and in the usage banner. Nothing tied the define to the tag, and nothing could have caught it
  — which also means any bug report triaged against a version string in that window was reading a stale one.

  `tests/check_version.bash` compares the define to an expected version and runs as a second job on any `v*` tag. It is a standalone script rather than
  logic buried in the workflow, so it can be run by hand like the other suites:

  ```
  $ bash tests/check_version.bash v0.2.2.14
  ok - VERSION is v0.2.2.14
  ```

  ## The version bump

  The define is bumped to `v0.2.2.14`, the next release. A minor bump rather than a patch because `14of22` is a documented seed option that used to abort
  and now works (#42), and the fourth component stays the monotonic counter it has been since `v0.1.2.7`.
   
  This means the PR should land before the tag is cut, or the new tag job will fail on its first run — which is, admittedly, the guard doing its job.
  
  ## Worth weighing
  
  This is the first CI in the repository, so it is a new thing for maintainers to own, and a red check on a contributor's PR is a cost that did not exist
  before. I think it is worth it: two fixes just merged on the strength of host-side tests that nothing ran automatically, and the version drift went
  unnoticed for five releases for exactly that reason. But it is a change in how the repo works, not just an addition to it.
  
  The `tests` job on this PR is its own first demonstration.