### PR TITLE
Harden three paths a code review found

### DIFF
--- a/common/cuda_utils.h
+++ b/common/cuda_utils.h
@@ -1,11 +1,23 @@
 #include <stdio.h>
+#include <unistd.h>
+
+// These run on TBB worker threads, with sibling workers still inside CUDA calls on
+// other GPUs.  exit() would run the destructors of the global thrust::device_vectors
+// underneath them, so the real message is followed by a "CUDA free failed:
+// cudaErrorCudartUnloading" cascade and a SIGABRT that buries it -- exactly what the
+// 14of22 seed-buffer overflow looked like in the field.  _exit() skips that; stderr
+// is flushed explicitly because _exit() does not.
+static inline void die_after(int code) {
+    fflush(stderr);
+    _exit(code);
+}
 
 // wrap of cudaSetDevice error checking in one place.  
 static inline void check_cuda_setDevice(int device_id, const char* tag) {
     cudaError_t err = cudaSetDevice(device_id);
     if (err != cudaSuccess) {
         fprintf(stderr, "Error: cudaSetDevice failed for device %d in %s failed with error \" %s \" \n", device_id, tag, cudaGetErrorString(err));
-        exit(11);
+        die_after(11);
     }
 }
 
@@ -14,7 +26,7 @@ static inline void check_cuda_malloc(void** buf, size_t bytes, const char* tag) 
     cudaError_t err = cudaMalloc(buf, bytes);
     if (err != cudaSuccess) {
         fprintf(stderr, "Error: cudaMalloc of %lu bytes for %s failed with error \" %s \" \n", bytes, tag, cudaGetErrorString(err));
-        exit(12);
+        die_after(12);
     }
 }
 	 
@@ -23,7 +35,7 @@ static inline void check_cuda_memcpy(void* dst_buf, void* src_buf, size_t bytes,
     cudaError_t err = cudaMemcpy(dst_buf, src_buf, bytes, kind);
     if (err != cudaSuccess) {
         fprintf(stderr, "Error: cudaMemcpy of %lu bytes for %s failed with error \" %s \" \n", bytes, tag, cudaGetErrorString(err));
-        exit(13);
+        die_after(13);
     }
 }
 	 
@@ -32,6 +44,6 @@ static inline void check_cuda_free(void* buf, const char* tag) {
     cudaError_t err = cudaFree(buf);
     if (err != cudaSuccess) {
         fprintf(stderr, "Error: cudaFree for %s failed with error \" %s \" \n", tag, cudaGetErrorString(err));
-        exit(14);
+        die_after(14);
     }
 }

--- a/common/parameters.h
+++ b/common/parameters.h
@@ -1,5 +1,16 @@
 #define VERSION "v0.2.2.14"
 
+// Upper bound on a seed pattern's weight (its count of match positions).
+//
+// 15, not 32, and the tighter bound is the load-bearing one: GetKmerIndexAtPos
+// packs two bits per match position into a uint32_t, and INVALID_KMER is 1<<31.
+// At weight 16 a legitimate k-mer can equal that sentinel and be discarded as
+// invalid; above 16 the k-mer wraps outright.  Staying at or below 15 also keeps
+// shape_pos[32]/transition_pos[32] in bounds, and keeps GetNumTransitions()
+// honest -- MaxSeedsPerChunk() sizes the GPU seed buffer from that count, so a
+// corrupted one silently breaks the capacity invariant.
+#define MAX_SEED_WEIGHT 15
+
 #define TRANSITION_MASK 2
 #define NUC 8 
 #define NUC2 NUC*NUC

--- a/common/scoring.c
+++ b/common/scoring.c
@@ -69,10 +69,9 @@ void load_scoring_matrix(int scoring_matrix[][L_NT], int* bad_score, int* fill_s
 	*bad_score  = recover_bad_score((scoreset*) xss);
 	*fill_score = recover_fill_score((scoreset*) xss);
 
-	if (xss != NULL) {
-		free_if_valid("score set", xss);
-		xss = NULL;
-	}
+	// No NULL check: read_score_set_by_name() calls suicide()/fopen_or_die() on
+	// every failure path, so it either returns a score set or does not return.
+	free_if_valid("score set", xss);
 }
 
 void build_substitution_matrix(int* sub_mat, int scoring_matrix[][L_NT], int bad_score, int fill_score, const char* ambiguous_field, int ambiguous_reward, int ambiguous_penalty, int xdrop) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -213,6 +213,12 @@ int main(int argc, char** argv){
 
     cfg.seed.kmer_size = GenerateShapePos(cfg.seed.shape);
 
+    if(cfg.seed.kmer_size < 1 || cfg.seed.kmer_size > MAX_SEED_WEIGHT){
+        fprintf(stderr, "Error: seed pattern \"%s\" has weight %d; must be 1 to %d\n",
+                cfg.seed.shape.c_str(), cfg.seed.kmer_size, MAX_SEED_WEIGHT);
+        return 1;
+    }
+
     if(vm.count("gappedthresh") == 0)
         cfg.gappedthresh = cfg.hspthresh; 
 

--- a/src/seed_filter.cu
+++ b/src/seed_filter.cu
@@ -692,7 +692,7 @@ std::vector<segmentPair> SeedAndFilter (std::vector<uint64_t> seed_offset_vector
     // buffer overrun reached cudaMemcpy() as a bare " invalid argument " instead.
     if (num_seeds > (uint64_t) MAX_SEEDS) {
         fprintf(stderr, "Error: %u seeds in one chunk exceeds the seed buffer capacity of %ld\n", num_seeds, MAX_SEEDS);
-        exit(15);
+        die_after(15);
     }
 
     uint64_t* tmp_offset = (uint64_t*) malloc(num_seeds*sizeof(uint64_t));


### PR DESCRIPTION
Three unrelated hardening changes from a review pass. None changes output.

**`exit()` from a TBB worker.** The four `check_cuda_*` helpers in `common/cuda_utils.h` called `exit()`. These run on TBB flow-graph worker threads, so `exit()` runs static destructors and flushes streams while other workers are still using them — turning a clean error report into a possible hang or a second, more confusing crash. They now call `die_after()`, which flushes stderr and uses `_exit()`.

**Unbounded seed weight.** `GetKmerIndexAtPos()` packs two bits per match position into a `uint32_t`, and `INVALID_KMER` is `1<<31`. At weight 16 a legitimate k-mer can equal that sentinel and be silently discarded as invalid; above 16 it wraps outright. `MAX_SEED_WEIGHT` names the limit at 15, and `main.cpp` rejects anything outside it with a message naming the pattern and its weight.

**A dead NULL guard in `common/scoring.c`,** removed, along with a comment recording why `bad_score` and `fill_score` must be recovered from the matrix rather than read as scalars.

Host-side suites pass. Compiles against CUDA 12.6 / gcc 13.

> **Merge this before "Bound the seed pattern arrays before the guard reports on them."** That branch is stacked on this one and fixes a defect in the weight guard added here: the guard runs *after* the arrays it protects have already been filled.
