### PR TITLE
Bound the seed pattern arrays before the guard reports on them

### DIFF
--- a/common/cuda_utils.h
+++ b/common/cuda_utils.h
@@ -1,11 +1,23 @@
 #include <stdio.h>
+#include <unistd.h>
+
+// These run on TBB worker threads, with sibling workers still inside CUDA calls on
+// other GPUs.  exit() would run the destructors of the global thrust::device_vectors
+// underneath them, so the real message is followed by a "CUDA free failed:
+// cudaErrorCudartUnloading" cascade and a SIGABRT that buries it -- exactly what the
+// 14of22 seed-buffer overflow looked like in the field.  _exit() skips that; stderr
+// is flushed explicitly because _exit() does not.
+static inline void die_after(int code) {
+    fflush(stderr);
+    _exit(code);
+}
 
 // wrap of cudaSetDevice error checking in one place.  
 static inline void check_cuda_setDevice(int device_id, const char* tag) {
     cudaError_t err = cudaSetDevice(device_id);
     if (err != cudaSuccess) {
         fprintf(stderr, "Error: cudaSetDevice failed for device %d in %s failed with error \" %s \" \n", device_id, tag, cudaGetErrorString(err));
-        exit(11);
+        die_after(11);
     }
 }
 
@@ -14,7 +26,7 @@ static inline void check_cuda_malloc(void** buf, size_t bytes, const char* tag) 
     cudaError_t err = cudaMalloc(buf, bytes);
     if (err != cudaSuccess) {
         fprintf(stderr, "Error: cudaMalloc of %lu bytes for %s failed with error \" %s \" \n", bytes, tag, cudaGetErrorString(err));
-        exit(12);
+        die_after(12);
     }
 }
 	 
@@ -23,7 +35,7 @@ static inline void check_cuda_memcpy(void* dst_buf, void* src_buf, size_t bytes,
     cudaError_t err = cudaMemcpy(dst_buf, src_buf, bytes, kind);
     if (err != cudaSuccess) {
         fprintf(stderr, "Error: cudaMemcpy of %lu bytes for %s failed with error \" %s \" \n", bytes, tag, cudaGetErrorString(err));
-        exit(13);
+        die_after(13);
     }
 }
 	 
@@ -32,6 +44,6 @@ static inline void check_cuda_free(void* buf, const char* tag) {
     cudaError_t err = cudaFree(buf);
     if (err != cudaSuccess) {
         fprintf(stderr, "Error: cudaFree for %s failed with error \" %s \" \n", tag, cudaGetErrorString(err));
-        exit(14);
+        die_after(14);
     }
 }

--- a/common/ntcoding.cpp
+++ b/common/ntcoding.cpp
@@ -19,12 +19,22 @@ inline uint32_t NtChar2Int (char nt) {
     }
 }
 
+// Returns the pattern's weight -- its true count of match positions, which may
+// exceed what shape_pos[] can hold.  The caller is expected to reject anything
+// above MAX_SEED_WEIGHT; this function must not corrupt memory while producing
+// the number that check is made against, so it stops writing at the bound and
+// keeps counting.
 int GenerateShapePos (std::string shape) {
     shape_size = 0;
     num_transitions = 0;
     int j = 0;
-    for (int i = 0; i < shape.length(); i++) {
+    int weight = 0;
+    for (size_t i = 0; i < shape.length(); i++) {
         if ((shape[i] == '1') || (shape[i] == 'T')) {
+            weight++;
+            if (shape_size >= MAX_SEED_WEIGHT) {
+                continue;
+            }
             shape_pos[shape_size++] = i;
             if (shape[i] == 'T') {
                 transition_pos[j] = 1;
@@ -36,7 +46,7 @@ int GenerateShapePos (std::string shape) {
             j++;
         }
     }
-    return shape_size;
+    return weight;
 }
 
 int IsTransitionAtPos(int t) {
@@ -51,7 +61,7 @@ int GetNumTransitions() {
 
 uint32_t GetKmerIndexAtPos (char* sequence, size_t pos, uint32_t seed_size) {
 
-    uint32_t nt[64];
+    uint32_t nt[MAX_SEED_SPAN];
 
     for(int i = 0; i < seed_size; i++){
         nt[i] = NtChar2Int(sequence[pos+i]);

--- a/common/parameters.h
+++ b/common/parameters.h
@@ -11,6 +11,14 @@
 // corrupted one silently breaks the capacity invariant.
 #define MAX_SEED_WEIGHT 15
 
+// Upper bound on a seed pattern's span (the length of the shape string).
+//
+// Independent of the weight above: "T" followed by ninety-nine zeroes has a
+// legal weight of 1 and a span of 100.  GetKmerIndexAtPos() reads the whole
+// span into a fixed nt[MAX_SEED_SPAN] before consulting shape_pos[], so an
+// unbounded span writes past that array once per candidate position.
+#define MAX_SEED_SPAN 64
+
 #define TRANSITION_MASK 2
 #define NUC 8 
 #define NUC2 NUC*NUC

--- a/common/parameters.h
+++ b/common/parameters.h
@@ -1,5 +1,16 @@
 #define VERSION "v0.2.2.14"
 
+// Upper bound on a seed pattern's weight (its count of match positions).
+//
+// 15, not 32, and the tighter bound is the load-bearing one: GetKmerIndexAtPos
+// packs two bits per match position into a uint32_t, and INVALID_KMER is 1<<31.
+// At weight 16 a legitimate k-mer can equal that sentinel and be discarded as
+// invalid; above 16 the k-mer wraps outright.  Staying at or below 15 also keeps
+// shape_pos[32]/transition_pos[32] in bounds, and keeps GetNumTransitions()
+// honest -- MaxSeedsPerChunk() sizes the GPU seed buffer from that count, so a
+// corrupted one silently breaks the capacity invariant.
+#define MAX_SEED_WEIGHT 15
+
 #define TRANSITION_MASK 2
 #define NUC 8 
 #define NUC2 NUC*NUC

--- a/common/scoring.c
+++ b/common/scoring.c
@@ -69,10 +69,9 @@ void load_scoring_matrix(int scoring_matrix[][L_NT], int* bad_score, int* fill_s
 	*bad_score  = recover_bad_score((scoreset*) xss);
 	*fill_score = recover_fill_score((scoreset*) xss);
 
-	if (xss != NULL) {
-		free_if_valid("score set", xss);
-		xss = NULL;
-	}
+	// No NULL check: read_score_set_by_name() calls suicide()/fopen_or_die() on
+	// every failure path, so it either returns a score set or does not return.
+	free_if_valid("score set", xss);
 }
 
 void build_substitution_matrix(int* sub_mat, int scoring_matrix[][L_NT], int bad_score, int fill_score, const char* ambiguous_field, int ambiguous_reward, int ambiguous_penalty, int xdrop) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -211,6 +211,12 @@ int main(int argc, char** argv){
         cfg.seed.size = seed_len;
     }
 
+    if(cfg.seed.size < 1 || cfg.seed.size > MAX_SEED_SPAN){
+        fprintf(stderr, "Error: seed pattern \"%s\" has span %d; must be 1 to %d\n",
+                cfg.seed.shape.c_str(), cfg.seed.size, MAX_SEED_SPAN);
+        return 1;
+    }
+
     cfg.seed.kmer_size = GenerateShapePos(cfg.seed.shape);
 
     if(cfg.seed.kmer_size < 1 || cfg.seed.kmer_size > MAX_SEED_WEIGHT){

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -213,6 +213,12 @@ int main(int argc, char** argv){
 
     cfg.seed.kmer_size = GenerateShapePos(cfg.seed.shape);
 
+    if(cfg.seed.kmer_size < 1 || cfg.seed.kmer_size > MAX_SEED_WEIGHT){
+        fprintf(stderr, "Error: seed pattern \"%s\" has weight %d; must be 1 to %d\n",
+                cfg.seed.shape.c_str(), cfg.seed.kmer_size, MAX_SEED_WEIGHT);
+        return 1;
+    }
+
     if(vm.count("gappedthresh") == 0)
         cfg.gappedthresh = cfg.hspthresh; 
 

--- a/src/seed_filter.cu
+++ b/src/seed_filter.cu
@@ -692,7 +692,7 @@ std::vector<segmentPair> SeedAndFilter (std::vector<uint64_t> seed_offset_vector
     // buffer overrun reached cudaMemcpy() as a bare " invalid argument " instead.
     if (num_seeds > (uint64_t) MAX_SEEDS) {
         fprintf(stderr, "Error: %u seeds in one chunk exceeds the seed buffer capacity of %ld\n", num_seeds, MAX_SEEDS);
-        exit(15);
+        die_after(15);
     }
 
     uint64_t* tmp_offset = (uint64_t*) malloc(num_seeds*sizeof(uint64_t));

--- a/tests/test_seed_capacity.cpp
+++ b/tests/test_seed_capacity.cpp
@@ -25,6 +25,7 @@
 #include <stdint.h>
 #include <string>
 
+#include "parameters.h"
 #include "ntcoding.h"
 #include "seed_capacity.h"
 
@@ -45,6 +46,17 @@ static void expect_at_least(const char* label, uint64_t actual, uint64_t floor)
     if (actual < floor) {
         printf("not ok - %s\n     got: %lu\nexpected at least: %lu (short by %lu)\n",
                label, actual, floor, floor - actual);
+        failures++;
+    } else {
+        printf("ok - %s\n", label);
+    }
+}
+
+static void expect_at_most(const char* label, uint64_t actual, uint64_t ceiling)
+{
+    if (actual > ceiling) {
+        printf("not ok - %s\n     got: %lu\nexpected at most: %lu (over by %lu)\n",
+               label, actual, ceiling, actual - ceiling);
         failures++;
     } else {
         printf("ok - %s\n", label);
@@ -123,6 +135,20 @@ int main()
     GenerateShapePos(SEED_14of22);
     expect_eq("notransition gives one seed per position",
               MaxSeedsPerChunk(false, GetNumTransitions(), chunk), chunk);
+
+    // --- an over-weight pattern must not corrupt the arrays it is rejected by -
+    // shape_pos[] and transition_pos[] hold 32 entries, and GenerateShapePos()
+    // used to fill them before any caller could check the weight -- so the guard
+    // that rejects the pattern ran only after the overrun it was meant to stop.
+    // GenerateShapePos() now stops writing at MAX_SEED_WEIGHT and keeps counting,
+    // so the weight it reports is still the true one the error message needs.
+    {
+        std::string over(40, 'T');
+        int weight = GenerateShapePos(over);
+        expect_eq("over-weight pattern still reports its true weight", weight, 40);
+        expect_at_most("over-weight pattern writes no more than the arrays hold",
+                       GetNumTransitions(), MAX_SEED_WEIGHT);
+    }
 
     if (failures > 0) {
         printf("\n%d test(s) failed\n", failures);


### PR DESCRIPTION
Stacked on **"Harden three paths a code review found"** — merge that one first; this branch contains its commit and the diff here will settle once it lands.

Fixes two memory-safety defects in seed pattern handling. Neither is reachable from input data — both need a deliberately odd `--seed` — but both corrupt silently instead of erroring, which is the opposite of what a guard is for.

## The weight guard ran after the overrun it exists to stop

`GenerateShapePos()` fills `shape_pos[32]` and `transition_pos[32]`, and the weight check runs afterwards. A pattern with 33 or more match positions overruns both arrays before the check can reject it.

The overrun is not abstract, and it corrupts exactly the values that matter:

- `shape_pos[32]` aliases `shape_size` — the weight itself. Writing it overwrites the loop counter mid-loop: on the pre-fix code, `GenerateShapePos()` given forty `T`s returns **39**.
- `transition_pos[32]` aliases `num_transitions` — the count `MaxSeedsPerChunk()` sizes the GPU seed buffer from, i.e. the invariant PR #42 restored.

`GenerateShapePos()` now stops writing at `MAX_SEED_WEIGHT` and keeps counting, so it still reports the true weight the caller's error message needs while never touching memory it does not own. Fixing the array rather than the caller covers the other caller too — the unit test drives it directly.

## The seed span was never validated at all

`cfg.seed.size` is the length of the `--seed` argument, assigned unchecked, and `GetKmerIndexAtPos()` reads the whole span into a fixed `nt[64]` before consulting `shape_pos[]`.

Weight and span are independent: `"T"` followed by ninety-nine zeroes has a legal weight of 1 and a span of 100, passes the weight guard, and writes 36 entries past the array. `MAX_SEED_SPAN` now names that bound, sizes the array, and is checked before `GenerateShapePos()` runs.

## Tests

`tests/test_seed_capacity.bash` gains two assertions. The first fails against the parent commit with `got: 39, expected: 40` — the corruption above, observed rather than argued.
