### PR TITLE
Keep the entropy counter inside its array

### DIFF
--- a/src/seed_filter.cu
+++ b/src/seed_filter.cu
@@ -331,6 +331,13 @@ void find_hsps (const char* __restrict__  d_ref_seq, const char* __restrict__  d
             ref_pos   = ref_loc[warp_id] + pos_offset;
             query_pos = query_loc[warp_id] + pos_offset;
             thread_score = 0;
+            // Lanes past the end of either sequence never assign these, yet the
+            // match test below reads them unconditionally -- uninitialised on the
+            // first tile, stale from the previous tile after that. Give them
+            // definite and deliberately UNEQUAL values, so such a lane is never
+            // counted and the index below cannot go negative.
+            r_chr = E_NT;
+            q_chr = A_NT;
 
             if(ref_pos < ref_len && query_pos < query_len){
                 r_chr = d_ref_seq[ref_pos];
@@ -444,7 +451,18 @@ void find_hsps (const char* __restrict__  d_ref_seq, const char* __restrict__  d
             }
             __syncwarp();
 
-            if(r_chr == q_chr){
+            // r_chr is a compressed code in 0..7, but count[] and count_del[] hold
+            // four entries -- only the real bases contribute to base-composition
+            // entropy. Without the bound, an aligned pair of masked bases, Ns, Xs
+            // or block separators writes past the arrays. LASTZ does the same thing
+            // safely by sizing its counter count[256] so the extra increments are
+            // discarded (compute_entropy, dna_utilities.c). That makes this bound
+            // safe and sensible, not provably identical to LASTZ: its
+            // entropy_lower_ok() variant folds lower case back into A/C/G/T, which
+            // KegAlign cannot do because compress_string collapses all four
+            // lower-case bases to the single code L_NT. Unreachable in practice --
+            // masked columns score bad_score and x-drop before being counted.
+            if(r_chr == q_chr && r_chr < L_NT){
                 if(pos_offset <= prev_max_pos[warp_id]){
                     count[r_chr] += 1;
                 }
@@ -481,6 +499,13 @@ void find_hsps (const char* __restrict__  d_ref_seq, const char* __restrict__  d
         while(!xdrop_found[warp_id] && !edge_found[warp_id]){
             pos_offset = lane_id+1+tile[warp_id];
             thread_score = 0;
+            // Lanes past the end of either sequence never assign these, yet the
+            // match test below reads them unconditionally -- uninitialised on the
+            // first tile, stale from the previous tile after that. Give them
+            // definite and deliberately UNEQUAL values, so such a lane is never
+            // counted and the index below cannot go negative.
+            r_chr = E_NT;
+            q_chr = A_NT;
 
             if(ref_loc[warp_id] >= pos_offset  && query_loc[warp_id] >= pos_offset){
                 ref_pos   = ref_loc[warp_id] - pos_offset;
@@ -595,7 +620,18 @@ void find_hsps (const char* __restrict__  d_ref_seq, const char* __restrict__  d
             }
             __syncwarp();
 
-            if(r_chr == q_chr){
+            // r_chr is a compressed code in 0..7, but count[] and count_del[] hold
+            // four entries -- only the real bases contribute to base-composition
+            // entropy. Without the bound, an aligned pair of masked bases, Ns, Xs
+            // or block separators writes past the arrays. LASTZ does the same thing
+            // safely by sizing its counter count[256] so the extra increments are
+            // discarded (compute_entropy, dna_utilities.c). That makes this bound
+            // safe and sensible, not provably identical to LASTZ: its
+            // entropy_lower_ok() variant folds lower case back into A/C/G/T, which
+            // KegAlign cannot do because compress_string collapses all four
+            // lower-case bases to the single code L_NT. Unreachable in practice --
+            // masked columns score bad_score and x-drop before being counted.
+            if(r_chr == q_chr && r_chr < L_NT){
                 if(pos_offset <= prev_max_pos[warp_id]){
                     count[r_chr] += 1;
                 }

--- a/src/seed_filter.cu
+++ b/src/seed_filter.cu
@@ -460,8 +460,11 @@ void find_hsps (const char* __restrict__  d_ref_seq, const char* __restrict__  d
             // safe and sensible, not provably identical to LASTZ: its
             // entropy_lower_ok() variant folds lower case back into A/C/G/T, which
             // KegAlign cannot do because compress_string collapses all four
-            // lower-case bases to the single code L_NT. Unreachable in practice --
-            // masked columns score bad_score and x-drop before being counted.
+            // lower-case bases to the single code L_NT.  That lower-case gap is
+            // unreachable in practice -- masked columns score bad_score and x-drop
+            // before being counted -- but the bound itself is NOT: two IUPAC codes
+            // in one column both compress to X_NT, compare equal, and score
+            // fill_score = -100 against an xdrop of 910, so they are counted.
             if(r_chr == q_chr && r_chr < L_NT){
                 if(pos_offset <= prev_max_pos[warp_id]){
                     count[r_chr] += 1;
@@ -629,8 +632,11 @@ void find_hsps (const char* __restrict__  d_ref_seq, const char* __restrict__  d
             // safe and sensible, not provably identical to LASTZ: its
             // entropy_lower_ok() variant folds lower case back into A/C/G/T, which
             // KegAlign cannot do because compress_string collapses all four
-            // lower-case bases to the single code L_NT. Unreachable in practice --
-            // masked columns score bad_score and x-drop before being counted.
+            // lower-case bases to the single code L_NT.  That lower-case gap is
+            // unreachable in practice -- masked columns score bad_score and x-drop
+            // before being counted -- but the bound itself is NOT: two IUPAC codes
+            // in one column both compress to X_NT, compare equal, and score
+            // fill_score = -100 against an xdrop of 910, so they are counted.
             if(r_chr == q_chr && r_chr < L_NT){
                 if(pos_offset <= prev_max_pos[warp_id]){
                     count[r_chr] += 1;


### PR DESCRIPTION
`find_hsps` writes past the end of its entropy counters.

```c
short count[4];                  // src/seed_filter.cu:266-267
short count_del[4];
...
if(r_chr == q_chr){              // r_chr is a compressed code in 0..7
    if(...) count[r_chr] += 1;
    else    count_del[r_chr] += 1;
}
```

`r_chr` comes from `d_ref_seq`, so it takes any of the eight compressed codes — `L_NT`=4, `N_NT`=5, `X_NT`=6, `E_NT`=7 alongside the four bases. The arrays hold four entries. It is reachable more often than the scoring suggests: a warp evaluates 32 positions in parallel and resolves x-drop termination by shuffle *afterwards*, so lanes past the stop point still execute the increment.

## Why this can change output

Indexing a local array out of range is undefined behaviour, so exactly what the write hits is a property of one build. But the two arrays are adjacent locals in the same frame, `count_del` **is** read back a few lines later by `count[i] = count[i] + count_del[i]`, and every landing site inside that frame is either a live counter or another live variable. So a non-nucleotide match either inflates a real base count or corrupts something else.

The counters feed the entropy factor, which multiplies `total_score` and gates HSP emission inside `[hspthresh, 3*hspthresh]` — and `d_hsp[].score` is `total_score` scaled by entropy, so this reaches the score written into the segments file, not merely a filter decision.

It is reachable with **stock flags and unmasked input**: `compress_string` maps every byte outside `ACGT/acgt/nN/&` to `X_NT`, so any two IUPAC ambiguity codes in one column compare equal, and `X_NT` against `X_NT` scores `fill_score = -100` by default — absorbed inside an HSP rather than triggering the 910 x-drop. `--ambiguous=iupac` widens it further by scoring `X_NT` against `X_NT` as a *reward*.

`r_chr` and `q_chr` are also assigned only inside the in-range guard yet read unconditionally by the match test, so a lane past the end of either sequence read them uninitialised on the first tile and stale afterwards. They are now set to definite, deliberately unequal values at the top of each tile, at both extension sites.

## This is a mis-sized port, not a design choice

LASTZ's `compute_entropy` does the same "increment blindly, read only ACGT" thing, with the same `>= 20` gate — but sizes the counter `count[256]` so incrementing `count['n']` is discarded rather than destructive. KegAlign shrank the array to 4 and kept the unguarded increment.

Bounding to the real bases is therefore memory-safe and follows LASTZ for the case that matters. It is **not** provably identical: LASTZ's `entropy_lower_ok()` variant folds lower case back into A/C/G/T, which KegAlign structurally cannot do because `compress_string` has already collapsed all four into `L_NT`. That gap is real and unclosable without a wider alphabet.

## What is not claimed

That this is observable in any measurement made so far. A differential run against `lastz --nogapped` with 50% of bases soft-masked was byte-identical — but that test **could not** exercise this: masked columns score `-1000` against an xdrop of 910, so they always take the `count_del` arm, which is the arm whose corruption falls outside the frame and is never read back. An input carrying IUPAC codes is what would show it.
