### PR TITLE
Release v0.3.0

### DIFF
--- a/common/parameters.h
+++ b/common/parameters.h
@@ -1,4 +1,4 @@
-#define VERSION "v0.2.2.14"
+#define VERSION "v0.3.0"
 
 // Upper bound on a seed pattern's weight (its count of match positions).
 //


### PR DESCRIPTION
Bumps `VERSION` to `v0.3.0` ahead of tagging. Nothing else changes.

**Why a minor bump and not a patch.** Output is not guaranteed bit-comparable with v0.2.2.14:

  - **#47** stops emitting duplicate segments, so a gapped extension LASTZ used to
    run twice now runs once. This one is measured: the differential test found
    exactly one duplicate in 1226 segments.
  - **#48** removes non-nucleotide matches from the entropy counters. Those feed a
    factor applied to `total_score` inside `[hspthresh, 3*hspthresh]`, so the
    change **can** move a borderline HSP or alter a written score — but no
    measurement so far shows it doing either. The 50%-masked differential run
    stayed byte-identical, and that run could not exercise the path in any case.
    It is filed as undefined behaviour and a mis-sized port of LASTZ's
    `compute_entropy`, not as a fix for wrong answers.

  Both are corrections rather than changes anyone asked for.

**Why plain semver.** The old four-component scheme's last element was a release counter that meant nothing outside this repository, and the first three moved irregularly. `v0.3.0` says what changed.

**Also in v0.3.0:** the seed buffer is sized for the seed pattern actually in use (#42 — the `14of22` crash on usegalaxy.org), a LASTZ scoring file's `bad_score` and `fill_score` are honoured rather than discarded (#43), the host-side tests run in CI and `VERSION` is tied to the tag (#44), CUDA worker threads no longer call `exit()` (#45), and the seed pattern arrays are bounded before the guard that rejects an over-long pattern reports on them (#46).

`tests/check_version.bash` passes against `v0.3.0` and fails against `v0.2.2.14`, so the tag job will gate the release rather than rubber-stamp it.

> **Before tagging:** the parity test (`tests/test_lastz_parity.bash`) has not been run against merged `main`. It needs a GPU, so CI skips it. Worth a run on the A100 host first, since #47 and #48 both change output.