### PR TITLE
Silence a sign-compare warning, and make the parity test parameterisable

### DIFF
--- a/common/ntcoding.cpp
+++ b/common/ntcoding.cpp
@@ -63,7 +63,7 @@ uint32_t GetKmerIndexAtPos (char* sequence, size_t pos, uint32_t seed_size) {
 
     uint32_t nt[MAX_SEED_SPAN];
 
-    for(int i = 0; i < seed_size; i++){
+    for(uint32_t i = 0; i < seed_size; i++){
         nt[i] = NtChar2Int(sequence[pos+i]);
         if (nt[i] == N_NT) {
             return INVALID_KMER;

--- a/tests/test_lastz_parity.bash
+++ b/tests/test_lastz_parity.bash
@@ -42,18 +42,38 @@
 # is 0-based half-open while start* is 1-based closed; KegAlign writes 1-based.
 #
 # The defaults are the repo's own test-data: 31 sequences, ~372 kb and ~377 kb,
-# which fit in ONE sequence block (default seq_block_size is 500 Mb). That matters.
-# KegAlign separates blocks with '&' and will not extend an HSP across one, while
-# LASTZ has no such boundary, so on a multi-block input some disagreement near
-# every block edge is EXPECTED and is not a parity defect.
+# which fit in ONE sequence block (default seq_block_size is 500 Mb).
+#
+# An earlier version of this comment claimed multi-block input would disagree
+# "because LASTZ has no such boundary". That was WRONG and is corrected here,
+# because it would license dismissing a real defect as expected noise. KegAlign's
+# '&' separators are only ever placed BETWEEN WHOLE FASTA RECORDS -- the block-size
+# test and the memset both run after a complete kseq record is appended
+# (main.cpp:338-390, and :494-509 for the reference) -- and LASTZ does not extend
+# an alignment across a record boundary either. Multi-block input is simply
+# UNTESTED here. Treat a genome-scale disagreement as a finding, not as expected.
+#
+# PARAMETERS are overridable from the environment, so an extra case needs no edit
+# and no copy of this script:
+#
+#     STEP=2 bash tests/test_lastz_parity.bash
+#     SEED=14of22 bash tests/test_lastz_parity.bash
+#
+# (Copying this file elsewhere and running it does NOT work: it locates test-data
+# relative to its own path.)
 set -o errexit -o nounset -o pipefail
 
 repo="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 
-# Held identical across both tools: KegAlign's defaults, spelled out.
-SEED=12of19 ; XDROP=910 ; HSPTHRESH=3000 ; STEP=1
+# Held identical across both tools: KegAlign's defaults, spelled out. Each can be
+# overridden from the environment to run this pair at another point in parameter
+# space; whatever is set here is passed to BOTH tools, which is the whole point.
+SEED="${SEED:-12of19}"
+XDROP="${XDROP:-910}"
+HSPTHRESH="${HSPTHRESH:-3000}"
+STEP="${STEP:-1}"
 
 need() { command -v "$1" >/dev/null || { echo "SKIP: $1 not on PATH"; exit 77; }; }
 need kegalign
@@ -157,6 +177,11 @@ run_case() {
         echo "ok - $label: KegAlign and LASTZ agree exactly, no duplicates"
     fi
 }
+
+# Print what was actually run. With the parameters overridable, a bare "1207 = 1207"
+# in a paste is unattributable -- and a result whose provenance is lost is a result
+# that gets attached to the wrong run later.
+printf 'seed=%s xdrop=%s hspthresh=%s step=%s\n' "$SEED" "$XDROP" "$HSPTHRESH" "$STEP"
 
 run_case unmasked "$tmp/target.fa"        "$tmp/query.fa"
 run_case masked   "$tmp/target.masked.fa" "$tmp/query.masked.fa"


### PR DESCRIPTION
Three small follow-ups from the v0.3.0 verification run. **No behaviour change to `kegalign` itself** — one compiler warning, one wrong comment, one test ergonomics fix.

### `-Wsign-compare` in `GetKmerIndexAtPos`

`for(int i = 0; i < seed_size; i++)` against a `uint32_t seed_size`. Pre-existing since `c75355a` (the original import), not introduced by the v0.3.0 bounds work — that commit only changed the adjacent `nt[]` declaration. It is now the only warning `common/ntcoding.cpp` emits.

### A stale comment in the parity test that asserts something false

The header claimed multi-block input would legitimately disagree "because LASTZ has no such boundary." It does not. KegAlign's `&` separators are only ever placed **between whole FASTA records** — the block-size test and the `memset` both run after a complete `kseq` record has been appended (`main.cpp:338-390`, and `:494-509` for the reference) — and LASTZ will not extend an alignment across a record boundary either. Multi-block input is simply **untested**.

Worth fixing rather than leaving: the old wording pre-authorised dismissing a real genome-scale disagreement as expected noise, which is about the most expensive thing a comment in a test can do.

### `SEED` / `XDROP` / `HSPTHRESH` / `STEP` now read from the environment

Running the pair at another point in parameter space previously needed a `sed`'d copy of the script — and a copy does not work, because the script locates `test-data` relative to its own path, so one in `/tmp` resolves the repo root to `/` and dies on `//test-data/apple.fasta.gz`. Now:

```bash
STEP=2    bash tests/test_lastz_parity.bash
SEED=14of22 bash tests/test_lastz_parity.bash
```

The run also prints the parameters it used. With them overridable, a bare `1207 = 1207` in a paste is unattributable, and a result whose provenance is lost is one that gets attached to the wrong run later.

This directly serves the "more cases" item: adding IUPAC, `14of22` and multi-block coverage is now an environment variable rather than an edit.

### Incidentally, `step=2` is already answered

Run on 4× A100 it agreed exactly — unmasked `1207 = 1207`, masked `461 = 461` — while the counts **moved** from 1225/469. The movement is the load-bearing half: had KegAlign been ignoring the flag on a side LASTZ honours, KegAlign would have stayed at 1225/469 while LASTZ fell. Both moved together.

The source agrees. LASTZ passes `currParams->step` only to `build_seed_position_table()` for the target (`lastz.c:1203,1214,1229,1305,1311`); in `seed_search.c` it appears only as `pt->step`, read back to reconstruct target coordinates, never to advance the query scan. That is exactly what KegAlign does with `cfg.step`.

---

Host-side suites pass; the parity test still skips cleanly without a GPU.