### PR TITLE
Reject seed patterns below weight 4

### DIFF
--- a/common/parameters.h
+++ b/common/parameters.h
@@ -11,6 +11,24 @@
 // corrupted one silently breaks the capacity invariant.
 #define MAX_SEED_WEIGHT 15
 
+// Lower bound on a seed pattern's weight.
+//
+// This is the bound GenerateSeedPosTable() already states -- assert(kmer_size > 3)
+// in common/seed_pos_table.cu -- promoted to something the shipped binary
+// enforces. NDEBUG deletes that assert in a Release build, the same way it
+// deleted the seed-buffer assert, which is how the 14of22 overflow reached a
+// user as a bare cudaMemcpy failure rather than an error message.
+//
+// What goes wrong below 4 is NOT the index table: at weight 1, 2 and 3 the table
+// holds 5, 17 and 65 entries and every k-mer the seeder can produce indexes
+// inside it. A weight-3 run was observed dying on a GPU with
+//
+//     thrust::system::system_error: device free failed: cudaErrorIllegalAddress
+//
+// and the mechanism behind that has not been established here. Do not read this
+// bound as a fix for that crash; read it as the upstream precondition, enforced.
+#define MIN_SEED_WEIGHT 4
+
 // Upper bound on a seed pattern's span (the length of the shape string).
 //
 // Independent of the weight above: "T" followed by ninety-nine zeroes has a

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -219,9 +219,9 @@ int main(int argc, char** argv){
 
     cfg.seed.kmer_size = GenerateShapePos(cfg.seed.shape);
 
-    if(cfg.seed.kmer_size < 1 || cfg.seed.kmer_size > MAX_SEED_WEIGHT){
-        fprintf(stderr, "Error: seed pattern \"%s\" has weight %d; must be 1 to %d\n",
-                cfg.seed.shape.c_str(), cfg.seed.kmer_size, MAX_SEED_WEIGHT);
+    if(cfg.seed.kmer_size < MIN_SEED_WEIGHT || cfg.seed.kmer_size > MAX_SEED_WEIGHT){
+        fprintf(stderr, "Error: seed pattern \"%s\" has weight %d; must be %d to %d\n",
+                cfg.seed.shape.c_str(), cfg.seed.kmer_size, MIN_SEED_WEIGHT, MAX_SEED_WEIGHT);
         return 1;
     }
 

--- a/tests/test_seed_capacity.cpp
+++ b/tests/test_seed_capacity.cpp
@@ -136,6 +136,21 @@ int main()
     expect_eq("notransition gives one seed per position",
               MaxSeedsPerChunk(false, GetNumTransitions(), chunk), chunk);
 
+    // --- the weight floor -------------------------------------------------
+    // GenerateSeedPosTable() asserts kmer_size > 3, and NDEBUG deletes that in
+    // a Release build. MIN_SEED_WEIGHT is what actually holds the line, so pin
+    // the two ends of the legal range against the assert they stand in for.
+    // This pins the constant to the assert it mirrors. It cannot execute that
+    // assert -- it is CUDA-side and NDEBUG deletes it anyway -- so it is a
+    // tripwire for the two drifting apart, not a test of the device code.
+    expect_eq("MIN_SEED_WEIGHT is the assert(kmer_size > 3) bound, +1",
+              MIN_SEED_WEIGHT, 4);
+    {
+        std::string w3(3, 'T'), w4(4, 'T');
+        expect_eq("a weight-3 pattern is below the floor", GenerateShapePos(w3), 3);
+        expect_eq("a weight-4 pattern is the smallest legal one", GenerateShapePos(w4), 4);
+    }
+
     // --- an over-weight pattern must not corrupt the arrays it is rejected by -
     // shape_pos[] and transition_pos[] hold 32 entries, and GenerateShapePos()
     // used to fill them before any caller could check the weight -- so the guard


### PR DESCRIPTION
`GenerateSeedPosTable()` asserts `kmer_size > 3`, and `NDEBUG` deletes that assert in a Release build. The CLI guard added in v0.3.0 only rejected weight `< 1`, so a pattern of weight 1, 2 or 3 passed the guard and passed the absent assert.

This is the same shape as the bug that opened this release cycle: a correct precondition stated in the source, absent from the binary anyone runs.

`MIN_SEED_WEIGHT` names the floor and the guard becomes a range; the error text states both ends.

## What this does not claim

An earlier version of this change said a low-weight pattern "indexed a 5-, 17- or 65-entry table with a k-mer the seeder had already truncated." **That is false**, and an adversarial review caught it. Enumerating every k-mer against the real `ntcoding.cpp`:

```
weight=1 index_table_size=5   max_kmer=3   in_bounds=yes
weight=2 index_table_size=17  max_kmer=15  in_bounds=yes
weight=3 index_table_size=65  max_kmer=63  in_bounds=yes
```

Nothing is truncated either — `GenerateShapePos()` stops writing only at `MAX_SEED_WEIGHT`.

A weight-3 run *was* observed dying on a GPU with `thrust::system::system_error: device free failed: cudaErrorIllegalAddress`, and the mechanism behind that is **not** established by this change. A plausible candidate is the `d_hsp` bound — `MAX_HITS` scales with device memory and the chunking loop can only split between seeds — which is a hit-buffer bound, not an index-table one, and weight 4 would not fix it.

So this enforces the upstream precondition, which is worth doing on its own terms. It is not offered as the fix for that crash.

## Tests

`tests/test_seed_capacity.cpp` pins the constant to the assert it mirrors. Stated plainly in the source: it is a tripwire for the two drifting apart, not a test of the device code — that assert is CUDA-side and `NDEBUG` deletes it anyway.

---

Independent of the other v0.3.1 branches; touches only C++ and the host-side test.
