### PR TITLE
Add ruff configuration and run it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,11 @@ jobs:
       - name: LASTZ scoring file is read in full
         run: bash tests/test_scoring.bash
 
+      - name: ruff
+        run: |
+          pipx run ruff check scripts tests
+          pipx run ruff format --check scripts tests
+
       - name: CUDA architecture selection
         run: cmake -P tests/test_cuda_architectures.cmake
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 build/
 test/
 bin/
+__pycache__/
+*.py[cod]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,62 @@
+# Tooling configuration only. KegAlign is a CUDA/C++ program built with CMake;
+# the Python here is the wrapper and orchestration layer under scripts/, plus
+# the host-side tests. There is no Python package to build or install.
+
+[tool.ruff]
+# The conda-forge kegalign recipe pins python 3.12.*, so that is what the
+# scripts must run on. (kegalign-full is noarch and declares no python of its
+# own.) Raising the target would let ruff emit UP043/UP037 rewrites which parse
+# on 3.12 but raise TypeError there at runtime.
+target-version = "py312"
+line-length = 120
+
+[tool.ruff.lint]
+select = [
+    "E", "W",    # pycodestyle
+    "F",         # pyflakes
+    "I",         # import ordering
+    "UP",        # pyupgrade -- modern type syntax
+    "B",         # flake8-bugbear
+    "SIM",       # flake8-simplify
+    "PL",        # pylint
+    "DTZ",       # naive datetimes
+    "RUF",
+]
+ignore = [
+    "PLR0912",   # too many branches -- runner.py's job dispatch is genuinely branchy
+    "PLR0915",   # too many statements -- same
+    "PLR2004",   # magic values; the constants here are documented in place
+    "PLR0913",   # too many arguments
+
+    # --- pre-existing, deliberately not fixed in the same change as the config -
+    # Enabling these is worthwhile but each is a behaviour change in a script
+    # that runs in production, and mixing that into a formatting commit makes a
+    # regression impossible to bisect. Counts are as of this commit; drop a code
+    # from this list and fix its sites in a change of its own.
+    "SIM115",    # 8  open() without a context manager -- real fd leaks
+    "PLW1510",   # 4  subprocess.run without check= -- errors currently ignored
+    "PLW2901",   # 9  loop variable overwritten in the body
+    "DTZ005",    # 6  datetime.now() without a timezone
+    "UP028",     # 3  yield from
+    "PLC0206",   # 4  dict iterated without .items()
+    "UP022",     # 3  subprocess capture_output
+    "SIM102",    # 3  collapsible nested if
+    "B905",      # 3  zip() without strict=
+    "E501",      # 13 long lines: 11 in scripts/mps-mig/, 1 each in
+                 #    run_lastz_tarball.py and runner.py
+    "B007",      # 3  unused loop control variable
+    "SIM105",    # 1  contextlib.suppress
+]
+
+[tool.ruff.lint.per-file-ignores]
+# The tests deliberately mirror runner.py's arithmetic; keep that readable.
+"tests/*.py" = ["PLR2004"]
+
+# scripts/mps-mig/ is not installed by the conda recipe -- it is a development
+# harness for MIG/MPS experiments. Two of these are dead locals that read as an
+# unfinished code path rather than as noise, so they are flagged here instead of
+# deleted: no_MIG is computed (and announced with "Using non-MIG GPU") but never
+# read, so the non-MIG mode may not actually be honoured, and non_mig_gpu_id sits
+# under its own "TODO make this non hardcoded". Someone who knows the intent
+# should decide; a linter should not.
+"scripts/mps-mig/*.py" = ["F841", "RUF059", "SIM113"]

--- a/scripts/diagonal_partition.py
+++ b/scripts/diagonal_partition.py
@@ -18,8 +18,9 @@ import typing
 
 import bashlex
 
+
 class nodevisitor(bashlex.ast.nodevisitor):  # type: ignore[misc]
-    def __init__(self, positions: typing.List[typing.Tuple[int, int]]) -> None:
+    def __init__(self, positions: list[tuple[int, int]]) -> None:
         self.positions = positions
         self.stdin = None
         self.stdout = None
@@ -51,10 +52,10 @@ class nodevisitor(bashlex.ast.nodevisitor):  # type: ignore[misc]
         pass
 
 
-def parse_line(line: str) -> typing.Dict[str, typing.Any]:
+def parse_line(line: str) -> dict[str, typing.Any]:
     # resolve shell redirects
-    trees: typing.List[typing.Any] = bashlex.parse(line, strictmode=False)
-    positions: typing.List[typing.Tuple[int, int]] = []
+    trees: list[typing.Any] = bashlex.parse(line, strictmode=False)
+    positions: list[tuple[int, int]] = []
 
     for tree in trees:
         visitor = nodevisitor(positions)
@@ -69,12 +70,7 @@ def parse_line(line: str) -> typing.Dict[str, typing.Any]:
 
     processed_line: str = "".join(processed)
 
-    command_dict = {
-        "line": processed_line,
-        "stdin": visitor.stdin,
-        "stdout": visitor.stdout,
-        "stderr": visitor.stderr
-    }
+    command_dict = {"line": processed_line, "stdin": visitor.stdin, "stdout": visitor.stdout, "stderr": visitor.stderr}
 
     return command_dict
 
@@ -82,7 +78,7 @@ def parse_line(line: str) -> typing.Dict[str, typing.Any]:
 def chunks(lst: tuple[str, ...], n: int) -> typing.Iterator[tuple[str, ...]]:
     """Yield successive n-sized chunks from list."""
     for i in range(0, len(lst), n):
-        yield lst[i:i + n]
+        yield lst[i : i + n]
 
 
 if __name__ == "__main__":
@@ -120,9 +116,9 @@ if __name__ == "__main__":
     input_file = None
 
     for index, value in enumerate(params):
-        if value[:len(segment_key)] == segment_key:
+        if value[: len(segment_key)] == segment_key:
             segment_index = index
-            input_file = value[len(segment_key):]
+            input_file = value[len(segment_key) :]
             break
 
     if segment_index is None:
@@ -137,7 +133,7 @@ if __name__ == "__main__":
     # each char is 1 byte
     line_size = None
     file_size = os.path.getsize(input_file)
-    with open(input_file, "r") as f:
+    with open(input_file) as f:
         # add 1 for newline
         line_size = len(f.readline())
 
@@ -158,7 +154,7 @@ if __name__ == "__main__":
             # if not enough segment files for estimation, use MAX_CHUNK_SIZE
             chunk_size = MAX_CHUNK_SIZE
         else:
-            fdict: typing.DefaultDict[str, int] = collections.defaultdict(int)
+            fdict: collections.defaultdict[str, int] = collections.defaultdict(int)
             for filename in files:
                 size = os.path.getsize(filename)
                 f_ = filename.split(".split", 1)[0]
@@ -177,7 +173,7 @@ if __name__ == "__main__":
             chunk_size = min(chunk_size, MAX_CHUNK_SIZE)
 
     # no need to sort if number of lines <= chunk_size
-    if (estimated_lines <= chunk_size):
+    if estimated_lines <= chunk_size:
         print(" ".join(params), flush=True)
         sys.exit(0)
 
@@ -191,12 +187,12 @@ if __name__ == "__main__":
     strand_key = "--strand="
     strand_index = None
     for index, value in enumerate(params):
-        if value[:len(output_key)] == output_key:
+        if value[: len(output_key)] == output_key:
             output_index = index
-            output_alignment_file = value[len(output_key):]
+            output_alignment_file = value[len(output_key) :]
             output_alignment_file_base, output_format = output_alignment_file.rsplit(".", 1)
 
-        if value[:len(strand_key)] == strand_key:
+        if value[: len(strand_key)] == strand_key:
             strand_index = index
 
     if output_alignment_file_base is None:
@@ -226,7 +222,7 @@ if __name__ == "__main__":
     else:
         sys.exit(f"Error: could not figure out direction from strand value {params[strand_index]}")
 
-    for line in open(input_file, "r"):
+    for line in open(input_file):
         if line == "":
             continue
         seq1_name, seq1_start, seq1_end, seq2_name, seq2_start, seq2_end, _dir, score = line.split()
@@ -251,22 +247,22 @@ if __name__ == "__main__":
 
     # NOTE: assuming data.keys() preserves order of keys. Requires Python 3.7+
 
-    query_key_order = list(dict.fromkeys([i[1] for i in data.keys()]))
+    query_key_order = list(dict.fromkeys([i[1] for i in data]))
 
     if len(data.keys()) > 1:
-        for pair in data.keys():
+        for pair in data:
             if len(data[pair]) <= chunk_size:
                 skip_pairs.append(pair)
 
     # sorting for forward segments
     if direction == "r":
-        for pair in data.keys():
+        for pair in data:
             if pair not in skip_pairs:
                 data[pair] = sorted(data[pair], key=lambda coord: (coord[1] - coord[0], coord[0]))
 
     # sorting for reverse segments
     elif direction == "f":
-        for pair in data.keys():
+        for pair in data:
             if pair not in skip_pairs:
                 data[pair] = sorted(data[pair], key=lambda coord: (coord[1] + coord[0], coord[0]))
     else:
@@ -275,7 +271,7 @@ if __name__ == "__main__":
     # Writing file in chunks
     ctr = 0
     # [i for i in data_keys if i not in set(skip_pairs)]:
-    for pair in (data.keys() - skip_pairs):
+    for pair in data.keys() - skip_pairs:
         for chunk in chunks(list(zip(*data[pair]))[2], chunk_size):
             ctr += 1
             name_addition = f".split{ctr}"

--- a/scripts/mps-mig/run_mig.py
+++ b/scripts/mps-mig/run_mig.py
@@ -3,11 +3,12 @@
 import argparse
 import datetime
 import os
-import pynvml
 import re
 import subprocess
 import sys
 import time
+
+import pynvml
 
 
 def check_makedir(pathname: str) -> None:
@@ -30,7 +31,9 @@ class NamedPopen(subprocess.Popen[str]):
 class GPU_queue:
     """ """
 
-    def __init__(self, device_names: list[str], uid_folder: str, uid_prefix: str = "UID_", max_processes: list[int] | None = None):
+    def __init__(
+        self, device_names: list[str], uid_folder: str, uid_prefix: str = "UID_", max_processes: list[int] | None = None
+    ):
         # dict of lists. Each list is for a GPU or MIG device which
         # holds UID values of processes running on that device
         self.queue: dict[str, list[str]] = {}
@@ -50,15 +53,17 @@ class GPU_queue:
                 self.max_processes[device_names[i]] = max_processes[i]
 
     def __len__(self) -> int:
-        return sum([len(i) for i in gpu_queue.get_queue().values()])
+        return sum(len(i) for i in self.get_queue().values())
 
     def submit(self, uid: str, device_name: str) -> None:
         self.queue[device_name].append(uid)
         self.submitted_uid.add(uid)
 
         if self.max_processes:
-            if (self.max_processes[device_name] < len(self.queue[device_name])):
-                sys.exit(f"WARNING for device {device_name}, max process = {self.max_processes[device_name]}, running process = {len(self.queue[device_name])}")
+            if self.max_processes[device_name] < len(self.queue[device_name]):
+                sys.exit(
+                    f"WARNING for device {device_name}, max process = {self.max_processes[device_name]}, running process = {len(self.queue[device_name])}"
+                )
 
     """
     Removes processes that completed their GPU part but not necessarily CPU (LASTZ) part.
@@ -66,7 +71,13 @@ class GPU_queue:
     """
 
     def check_completion(self) -> None:
-        completed_uid = set([f for f in os.listdir(self.uid_folder) if self.uid_prefix in f and os.path.isfile(os.path.join(self.uid_folder, f))])
+        completed_uid = set(
+            [
+                f
+                for f in os.listdir(self.uid_folder)
+                if self.uid_prefix in f and os.path.isfile(os.path.join(self.uid_folder, f))
+            ]
+        )
 
         # check successfully completed jobs using file output from modified run_kegalign script
         uids_in_progress = completed_uid - self.completed_uid_history
@@ -324,27 +335,68 @@ def parse_args() -> argparse.Namespace:
     # TODO most variables with 'mig' in the name are misleading. They are used for both MIG and non-MIG GPUs. Need to rename these
     parser = argparse.ArgumentParser()
     parser.add_argument("--MIG", type=str, default="", help="Comma separated list of GPU or MIG device names")
-    parser.add_argument("--MPS", type=str, default="", help="Comma separated list of number of processes per GPU/MIG node.")
-    parser.add_argument("--kill_mps", action="store_true", help="Shutdown all MPS daemons. Does not run aligmnet. Used for debug purposes or when run_mig script improperly terminated.")
+    parser.add_argument(
+        "--MPS", type=str, default="", help="Comma separated list of number of processes per GPU/MIG node."
+    )
+    parser.add_argument(
+        "--kill_mps",
+        action="store_true",
+        help="Shutdown all MPS daemons. Does not run aligmnet. Used for debug purposes or when run_mig script improperly terminated.",
+    )
     # parser.add_argument("--skip_mps_init", action="store_true")
-    parser.add_argument("--refresh", type=float, default=0.2, help="Time in seconds to wait before checking for free GPU or MIG devices")
+    parser.add_argument(
+        "--refresh", type=float, default=0.2, help="Time in seconds to wait before checking for free GPU or MIG devices"
+    )
     # parser.add_argument("--usev", type=str, default="")
     parser.add_argument("--query", type=str, required=True, help="Directory containing partitioned input query file.")
     parser.add_argument("--target", type=str, required=True, help="Directory containing partitioned input target file.")
     parser.add_argument("--tmp_dir", type=str, required=True, help="Directory to store temporary files.")
     parser.add_argument("--output", type=str, required=True, help="Output alignment file name.")
-    parser.add_argument("--format", type=str, default="maf-", help="Output alignment file format. Must be supported by KegAlign, i.e. able to be concatenated.")
+    parser.add_argument(
+        "--format",
+        type=str,
+        default="maf-",
+        help="Output alignment file format. Must be supported by KegAlign, i.e. able to be concatenated.",
+    )
     parser.add_argument("--mps_pipe_dir", type=str, help="MPS pipe directory.")
-    parser.add_argument("--num_threads", type=int, default=-1, help="Number of threads to use for each KegAlign process.")
-    parser.add_argument("--segment_size", type=int, default=0, help="Maximum segment size output by KegAlign. Segment files larger than this parameter are partitioned. 0 does no partitioning, -1 estimates best partition size. See diagonal_partition.py")
-    parser.add_argument("--kegalign_cmd", type=str, default="run_kegalign_symlink", help="Command to KegAlign runner script. This is called when aligning each pair of query and target files.")
+    parser.add_argument(
+        "--num_threads", type=int, default=-1, help="Number of threads to use for each KegAlign process."
+    )
+    parser.add_argument(
+        "--segment_size",
+        type=int,
+        default=0,
+        help="Maximum segment size output by KegAlign. Segment files larger than this parameter are partitioned. 0 does no partitioning, -1 estimates best partition size. See diagonal_partition.py",
+    )
+    parser.add_argument(
+        "--kegalign_cmd",
+        type=str,
+        default="run_kegalign_symlink",
+        help="Command to KegAlign runner script. This is called when aligning each pair of query and target files.",
+    )
     parser.add_argument("--opt_cmd", type=str, default="", help="Additional options to pass to KegAlign runner script.")
-    parser.add_argument("--keep_partial", action="store_true", help="Keep output files for each pair of alignments after combining them. It is recommended to keep these files for debugging purposes or if output file format does not support concatenation.")
-    parser.add_argument("--only_missing", action="store_true", help="Only run KegAlign for missing pairs of query and target files, if any failed for some reason.")
-    parser.add_argument("--skip_mps_control", action="store_true", help="Skip starting and stopping MPS daemon. Used for debugging purposes.")
-    parser.add_argument("--start_uid", type=int, default=None, help="Start alignmet from a specific pair. Used for debugging purposes.")
+    parser.add_argument(
+        "--keep_partial",
+        action="store_true",
+        help="Keep output files for each pair of alignments after combining them. It is recommended to keep these files for debugging purposes or if output file format does not support concatenation.",
+    )
+    parser.add_argument(
+        "--only_missing",
+        action="store_true",
+        help="Only run KegAlign for missing pairs of query and target files, if any failed for some reason.",
+    )
+    parser.add_argument(
+        "--skip_mps_control",
+        action="store_true",
+        help="Skip starting and stopping MPS daemon. Used for debugging purposes.",
+    )
+    parser.add_argument(
+        "--start_uid", type=int, default=None, help="Start alignmet from a specific pair. Used for debugging purposes."
+    )
     parser.add_argument("--verbose", action="store_true", help="Print additional information to console.")
-    parser.add_argument("--twobit_ext", type=str, default=".2bit", help="File extensions of 2bit files in query and target directories.")
+    parser.add_argument(
+        "--twobit_ext", type=str, default=".2bit", help="File extensions of 2bit files in query and target directories."
+    )
     parser.add_argument("--resubmit_fails", action="store_false", help="Whether to resubmit failed alignment pairs.")
 
     return parser.parse_args()
@@ -381,7 +433,7 @@ def main() -> None:
     try:
         pynvml.nvmlInit()
     except pynvml.NVMLError as e:
-        sys.exit(f"ERROR: {str(e)}")
+        sys.exit(f"ERROR: {e!s}")
 
     timer = datetime.datetime.now()
     # TODO script currently only supports 1 GPU per KegAlign process. Add multiple GPU support if needed
@@ -425,7 +477,9 @@ def main() -> None:
 
     _2bit_extension = args.twobit_ext
     query_block_file_names = sorted([filename for filename in os.listdir(query_dir) if _2bit_extension not in filename])
-    target_block_file_names = sorted([filename for filename in os.listdir(target_dir) if _2bit_extension not in filename])
+    target_block_file_names = sorted(
+        [filename for filename in os.listdir(target_dir) if _2bit_extension not in filename]
+    )
 
     process_list = Process_List()
 
@@ -564,14 +618,20 @@ def main() -> None:
                         part += 1
                         continue
                 # run process in non blocking way
-                process = NamedPopen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, shell=True, name=uid_name)
+                process = NamedPopen(
+                    command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, shell=True, name=uid_name
+                )
                 process_list.append(process)
                 gpu_queue.submit(uid_name, mig_device)
                 # sum([len(i) for i in gpu_queue.get_queue().values()])
                 running = len(gpu_queue)
-                est_runtime = str((datetime.datetime.now() - timer) * (total_pairs / max(total_pairs - len(pairs) - running, 1))).split(".", 1)[0]
+                est_runtime = str(
+                    (datetime.datetime.now() - timer) * (total_pairs / max(total_pairs - len(pairs) - running, 1))
+                ).split(".", 1)[0]
                 if verbose:
-                    print(f"running process with pid={process.pid}, uid={uid_name} and mig_uuid={mig_device}. part {part} /{total_pairs}: {t} and {q}. Elapsed Time: {get_time(timer)}, estimated runtime: {est_runtime} [len(pairs) {len(pairs)}, running {running}]")
+                    print(
+                        f"running process with pid={process.pid}, uid={uid_name} and mig_uuid={mig_device}. part {part} /{total_pairs}: {t} and {q}. Elapsed Time: {get_time(timer)}, estimated runtime: {est_runtime} [len(pairs) {len(pairs)}, running {running}]"
+                    )
                     print(command)
                 # process_list.append(process)
                 mig_process_dict = gpu_queue.get_queue()
@@ -613,7 +673,7 @@ def main() -> None:
         output_file_list = [i for i in os.listdir(tmp_dir) if i.startswith("part_") and i.endswith(f".{output_format}")]
         expected_outputs = len(query_block_file_names) * len(target_block_file_names)
         if len(output_file_list) != expected_outputs:
-            print(f"Missing {expected_outputs-len(output_file_list)} output parts: ")
+            print(f"Missing {expected_outputs - len(output_file_list)} output parts: ")
             set_output_file_list = set(output_file_list)
 
             for k in range(1, expected_outputs + 1):
@@ -625,7 +685,6 @@ def main() -> None:
 
         normal_completion = True
     finally:
-
         if not normal_completion:
             output_stdout, output_stderr = process_list.get_output(terminate=True)
             if use_MPS and not bool(int(args.skip_mps_control)):
@@ -649,7 +708,9 @@ def main() -> None:
 
         print(f"total time {get_time(timer)}")
         python_log += f"total time {get_time(timer)}\n"
-        combine_results(tmp_dir, output_file, part_pattern=f"part_*.{output_format}", remove=(not bool(args.keep_partial)))
+        combine_results(
+            tmp_dir, output_file, part_pattern=f"part_*.{output_format}", remove=(not bool(args.keep_partial))
+        )
         print(f"result combination finished at {get_time(timer)}")
         python_log += f"result combination finished at {get_time(timer)}\n"
         python_log += f"Ending Time: {datetime.datetime.now()}\n"
@@ -668,7 +729,7 @@ def main() -> None:
         try:
             pynvml.nvmlShutdown()
         except pynvml.NVMLError as e:
-            sys.exit(f"ERROR: {str(e)}")
+            sys.exit(f"ERROR: {e!s}")
 
 
 if __name__ == "__main__":

--- a/scripts/mps-mig/split_input.py
+++ b/scripts/mps-mig/split_input.py
@@ -36,23 +36,17 @@ RUSAGE_ATTRS: typing.Final = [
     "ru_nivcsw",
 ]
 
-FastaSequence = collections.namedtuple(
-    "FastaSequence", ["description", "sequence", "length"], defaults=["", "", 0]
-)
+FastaSequence = collections.namedtuple("FastaSequence", ["description", "sequence", "length"], defaults=["", "", 0])
 
 
-def debug_start(
-    who: int = resource.RUSAGE_SELF, message: str = ""
-) -> tuple[resource.struct_rusage, int, int]:
+def debug_start(who: int = resource.RUSAGE_SELF, message: str = "") -> tuple[resource.struct_rusage, int, int]:
     print(f"DEBUG: {message}", file=sys.stderr, flush=True)
     r_beg = resource.getrusage(who)
     beg = time.monotonic_ns()
     return r_beg, beg, who
 
 
-def debug_end(
-    r_beg: resource.struct_rusage, beg: int, who: int, message: str = ""
-) -> None:
+def debug_end(r_beg: resource.struct_rusage, beg: int, who: int, message: str = "") -> None:
     ns = time.monotonic_ns() - beg
     r_end = resource.getrusage(who)
     print(f"DEBUG: {message}: {ns} ns", file=sys.stderr, flush=True)
@@ -73,9 +67,7 @@ class FastaFile:
         seqs: list[str] = []
 
         if args.debug:
-            debug_r_beg, debug_beg, debug_who = debug_start(
-                resource.RUSAGE_SELF, f"loading fasta {self.pathname}"
-            )
+            debug_r_beg, debug_beg, debug_who = debug_start(resource.RUSAGE_SELF, f"loading fasta {self.pathname}")
 
         with self._get_open_method() as f:
             for line in f:
@@ -84,9 +76,7 @@ class FastaFile:
                 if line.startswith(">"):
                     if seqs:
                         sequence = "".join(seqs)
-                        self.sequences.append(
-                            FastaSequence(description, sequence, len(sequence))
-                        )
+                        self.sequences.append(FastaSequence(description, sequence, len(sequence)))
                         seqs.clear()
 
                     description = line
@@ -95,9 +85,7 @@ class FastaFile:
 
             if seqs:
                 sequence = "".join(seqs)
-                self.sequences.append(
-                    FastaSequence(description, sequence, len(sequence))
-                )
+                self.sequences.append(FastaSequence(description, sequence, len(sequence)))
 
         if args.debug:
             debug_end(
@@ -117,7 +105,7 @@ class FastaFile:
         except Exception:
             pass
 
-        return open(self.pathname, mode="rt")
+        return open(self.pathname)
 
     @property
     def total_bases(self) -> int:
@@ -138,9 +126,7 @@ class FastaFile:
         self.sequences.clear()
         self.sequences.append(FastaSequence(description, sequence, len(sequence)))
 
-    def discard_sequences_after_and_including(
-        self, description: str, debug: bool = False
-    ) -> None:
+    def discard_sequences_after_and_including(self, description: str, debug: bool = False) -> None:
         split_index = -1
         for idx, sequence in enumerate(self.sequences):
             if sequence.description == f">{description}":
@@ -177,8 +163,7 @@ def convert_to_2bit(root_dir: str) -> None:
 
     cpus_available = len(os.sched_getaffinity(0))
     num_commands = len(commands)
-    if cpus_available > num_commands:
-        cpus_available = num_commands
+    cpus_available = min(cpus_available, num_commands)
 
     if args.debug:
         print(
@@ -193,9 +178,7 @@ def convert_to_2bit(root_dir: str) -> None:
 
 
 def twobit_wrapper(command: str) -> None:
-    process = subprocess.Popen(
-        command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, shell=True
-    )
+    process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, shell=True)
     stdout, stderr = process.communicate()
     if stdout:
         print(f"{stdout}", file=sys.stdout)
@@ -242,9 +225,7 @@ def split_chr(
             bin_size += target_fasta.sequences[ind].length
 
         if debug:
-            print(
-                f"DEBUG: chunk_{bin_no} num bp {bin_size}", file=sys.stderr, flush=True
-            )
+            print(f"DEBUG: chunk_{bin_no} num bp {bin_size}", file=sys.stderr, flush=True)
 
         chunk_size_list.append(bin_size)
         block_file_name = os.path.join(output_dir, f"chunk_{bin_no}")
@@ -288,9 +269,7 @@ if __name__ == "__main__":
         help="Input sequence in fasta or fasta.gz format",
     )
     parser.add_argument("--out", type=str, required=True, help="Output directory")
-    parser.add_argument(
-        "--to_2bit", action="store_true", help="Convert partitioned inputs into .2bit format"
-    )
+    parser.add_argument("--to_2bit", action="store_true", help="Convert partitioned inputs into .2bit format")
 
     parser.add_argument(
         "--max_chunks",
@@ -322,7 +301,7 @@ if __name__ == "__main__":
 
     if not os.path.exists(args.input):
         print(f"Input file {args.input} does not exist.")
-        exit(1)
+        sys.exit(1)
 
     os.makedirs(target_block_dir, exist_ok=True)
 
@@ -335,13 +314,10 @@ if __name__ == "__main__":
         # prevents parallel execution. As a workaround, pass the input file path
         # and initialize FastFile object in parallel_wrapper
         # TODO: find a better way to do this
-        pass_list = [
-            (target_file, "", i, False, False) for i in range(1, bin_count + 1)
-        ]
+        pass_list = [(target_file, "", i, False, False) for i in range(1, bin_count + 1)]
 
         cpus_available = len(os.sched_getaffinity(0))
-        if cpus_available > bin_count:
-            cpus_available = bin_count
+        cpus_available = min(cpus_available, bin_count)
 
         if args.debug:
             print(
@@ -350,9 +326,7 @@ if __name__ == "__main__":
                 flush=True,
             )
 
-        with concurrent.futures.ProcessPoolExecutor(
-            max_workers=cpus_available
-        ) as executor:
+        with concurrent.futures.ProcessPoolExecutor(max_workers=cpus_available) as executor:
             for bins in executor.map(parallel_wrapper, pass_list):
                 i = len(bins)
                 loss = mse(bins, goal_bp)
@@ -372,7 +346,6 @@ if __name__ == "__main__":
     else:
         bin_count = args.max_chunks
     if args.debug:
-
         if args.goal_bp:
             print(
                 print(f"bin_count = {bin_count}, loss={best_bin_loss}"),

--- a/scripts/package_output.py
+++ b/scripts/package_output.py
@@ -12,7 +12,17 @@ import typing
 
 import bashlex
 
-RUSAGE_ATTRS: typing.Final = ["ru_utime", "ru_stime", "ru_maxrss", "ru_minflt", "ru_majflt", "ru_inblock", "ru_oublock", "ru_nvcsw", "ru_nivcsw"]
+RUSAGE_ATTRS: typing.Final = [
+    "ru_utime",
+    "ru_stime",
+    "ru_maxrss",
+    "ru_minflt",
+    "ru_majflt",
+    "ru_inblock",
+    "ru_oublock",
+    "ru_nvcsw",
+    "ru_nivcsw",
+]
 
 
 class PackageFile:
@@ -22,7 +32,7 @@ class PackageFile:
         top_dir: str = "galaxy",
         data_dir: str = "files",
         config_file: str = "commands.json",
-        format_file: str = "format.txt"
+        format_file: str = "format.txt",
     ) -> None:
         self.pathname: str = os.path.realpath(pathname)
         self.data_root: str = os.path.join(top_dir, data_dir)
@@ -30,8 +40,8 @@ class PackageFile:
         self.config_file: str = config_file
         self.format_path: str = os.path.join(top_dir, format_file)
         self.format_file: str = format_file
-        self.tarfile: typing.Optional[tarfile.TarFile] = None
-        self.name_cache: typing.Dict[typing.Any, typing.Any] = {}
+        self.tarfile: tarfile.TarFile | None = None
+        self.name_cache: dict[typing.Any, typing.Any] = {}
         self.working_dir: str = os.path.realpath(os.getcwd())
 
     def _initialize(self) -> None:
@@ -52,7 +62,7 @@ class PackageFile:
         if self.tarfile is not None:
             self.tarfile.add(source_path, arcname=self.config_path, recursive=False)
 
-    def add_file(self, pathname: str, arcname: typing.Optional[str] = None) -> None:
+    def add_file(self, pathname: str, arcname: str | None = None) -> None:
         if self.tarfile is None:
             self._initialize()
 
@@ -74,9 +84,7 @@ class PackageFile:
             if self.tarfile is not None:
                 if dest_path not in self.name_cache:
                     try:
-                        self.tarfile.add(
-                            source_path, arcname=dest_path, recursive=False
-                        )
+                        self.tarfile.add(source_path, arcname=dest_path, recursive=False)
                     except FileNotFoundError:
                         sys.exit(f"missing source file {source_path}")
 
@@ -110,69 +118,68 @@ class bashCommandLineFile:
         self.config = config
         self.args = args
         self.package_file = package_file
-        self.executable: typing.Optional[str] = None
+        self.executable: str | None = None
         self._parse_lines()
         self._write_format()
 
     def _parse_lines(self) -> None:
-        with open("commands.json", "w") as ofh:
-            with open(self.pathname) as f:
-                line: str
-                for line in f:
-                    line = line.rstrip("\n")
-                    command_dict = self._parse_line(line)
-                    # we may want to re-write args here
-                    new_args_list = []
+        with open("commands.json", "w") as ofh, open(self.pathname) as f:
+            line: str
+            for line in f:
+                line = line.rstrip("\n")
+                command_dict = self._parse_line(line)
+                # we may want to re-write args here
+                new_args_list = []
 
-                    args_list = command_dict.get("args", [])
-                    for arg in args_list:
-                        if arg.startswith("--target="):
-                            pathname = arg[9:]
-                            new_args_list.append(arg)
-                            if "[" in pathname:
-                                elems = pathname.split("[")
-                                sequence_file = elems.pop(0)
-                                self.package_file.add_file(sequence_file, sequence_file)
-                                for elem in elems:
-                                    if elem.endswith("]"):
-                                        elem = elem[:-1]
-                                        if elem.startswith("subset="):
-                                            subset_file = elem[7:]
-                                            self.package_file.add_file(subset_file)
+                args_list = command_dict.get("args", [])
+                for arg in args_list:
+                    if arg.startswith("--target="):
+                        pathname = arg[9:]
+                        new_args_list.append(arg)
+                        if "[" in pathname:
+                            elems = pathname.split("[")
+                            sequence_file = elems.pop(0)
+                            self.package_file.add_file(sequence_file, sequence_file)
+                            for elem in elems:
+                                if elem.endswith("]"):
+                                    elem = elem[:-1]
+                                    if elem.startswith("subset="):
+                                        subset_file = elem[7:]
+                                        self.package_file.add_file(subset_file)
 
-                        elif arg.startswith("--query="):
-                            pathname = arg[8:]
-                            new_args_list.append(arg)
-                            if "[" in pathname:
-                                elems = pathname.split("[")
-                                sequence_file = elems.pop(0)
-                                self.package_file.add_file(sequence_file, sequence_file)
-                                for elem in elems:
-                                    if elem.endswith("]"):
-                                        elem = elem[:-1]
-                                        if elem.startswith("subset="):
-                                            subset_file = elem[7:]
-                                            self.package_file.add_file(subset_file)
-                        elif arg.startswith("--segments="):
-                            pathname = arg[11:]
-                            new_args_list.append(arg)
-                            self.package_file.add_file(pathname)
-                        elif arg.startswith("--scores="):
-                            pathname = arg[9:]
-                            new_args_list.append("--scores=data/scores.txt")
-                            self.package_file.add_file(pathname, "data/scores.txt")
-                        else:
-                            new_args_list.append(arg)
+                    elif arg.startswith("--query="):
+                        pathname = arg[8:]
+                        new_args_list.append(arg)
+                        if "[" in pathname:
+                            elems = pathname.split("[")
+                            sequence_file = elems.pop(0)
+                            self.package_file.add_file(sequence_file, sequence_file)
+                            for elem in elems:
+                                if elem.endswith("]"):
+                                    elem = elem[:-1]
+                                    if elem.startswith("subset="):
+                                        subset_file = elem[7:]
+                                        self.package_file.add_file(subset_file)
+                    elif arg.startswith("--segments="):
+                        pathname = arg[11:]
+                        new_args_list.append(arg)
+                        self.package_file.add_file(pathname)
+                    elif arg.startswith("--scores="):
+                        pathname = arg[9:]
+                        new_args_list.append("--scores=data/scores.txt")
+                        self.package_file.add_file(pathname, "data/scores.txt")
+                    else:
+                        new_args_list.append(arg)
 
-                    command_dict["args"] = new_args_list
-                    print(json.dumps(command_dict), file=ofh)
+                command_dict["args"] = new_args_list
+                print(json.dumps(command_dict), file=ofh)
 
         self.package_file.add_config("commands.json")
 
-    def _parse_line(self, line: str) -> typing.Dict[str, typing.Any]:
+    def _parse_line(self, line: str) -> dict[str, typing.Any]:
         # resolve shell redirects
-        trees: typing.List[typing.Any] = bashlex.parse(line, strictmode=False)
-        positions: typing.List[typing.Tuple[int, int]] = []
+        trees: list[typing.Any] = bashlex.parse(line, strictmode=False)
+        positions: list[tuple[int, int]] = []
 
         for tree in trees:
             visitor = nodevisitor(positions)
@@ -194,8 +201,8 @@ class bashCommandLineFile:
 
         return command_dict
 
-    def _parse_processed_line(self, line: str) -> typing.Dict[str, typing.Any]:
-        argv: typing.List[str] = list(bashlex.split(line))
+    def _parse_processed_line(self, line: str) -> dict[str, typing.Any]:
+        argv: list[str] = list(bashlex.split(line))
         self.executable = argv.pop(0)
 
         parser: argparse.ArgumentParser = argparse.ArgumentParser(add_help=False)
@@ -213,9 +220,7 @@ class bashCommandLineFile:
 
             if "bool_str_args" in arguments_section:
                 for arg in arguments_section["bool_str_args"].split():
-                    parser.add_argument(
-                        f"--{arg}", nargs="?", const=True, default=False
-                    )
+                    parser.add_argument(f"--{arg}", nargs="?", const=True, default=False)
 
             if "int_args" in arguments_section:
                 for arg in arguments_section["int_args"].split():
@@ -223,19 +228,17 @@ class bashCommandLineFile:
 
             if "bool_int_args" in arguments_section:
                 for arg in arguments_section["bool_int_args"].split():
-                    parser.add_argument(
-                        f"--{arg}", nargs="?", const=True, default=False
-                    )
+                    parser.add_argument(f"--{arg}", nargs="?", const=True, default=False)
 
         namespace, rest = parser.parse_known_intermixed_args(argv)
         vars_dict = vars(namespace)
 
-        command_dict: typing.Dict[str, typing.Any] = {
+        command_dict: dict[str, typing.Any] = {
             "executable": self.executable,
             "args": [],
         }
 
-        for var in vars_dict.keys():
+        for var in vars_dict:
             value = vars_dict[var]
             if value is not None:
                 if isinstance(value, bool):
@@ -273,7 +276,7 @@ class bashCommandLineFile:
 
 
 class nodevisitor(bashlex.ast.nodevisitor):  # type: ignore[misc]
-    def __init__(self, positions: typing.List[typing.Tuple[int, int]]) -> None:
+    def __init__(self, positions: list[tuple[int, int]]) -> None:
         self.positions = positions
         self.stdin = None
         self.stdout = None

--- a/scripts/run_lastz_tarball.py
+++ b/scripts/run_lastz_tarball.py
@@ -19,7 +19,7 @@ import typing
 
 
 @contextlib.contextmanager
-def open_file(filename: str):
+def open_file(filename: str) -> typing.Iterator[typing.IO[str]]:
     if filename.endswith(".gz"):
         with gzip.open(filename, "wt", compresslevel=6) as f:
             yield f
@@ -35,12 +35,12 @@ lastz_output_format_regex = re.compile(
 
 
 # Specifies the output format: lav, lav+text, axt, axt+, maf, maf+, maf-, sam, softsam, sam-, softsam-, cigar, BLASTN, PAF, PAF:wfmash, differences, rdotplot, text, general[:<fields>], or general-[:<fields>].
-# ‑‑format=none can be used when no alignment output is desired.
+# --format=none can be used when no alignment output is desired.
 
 
 def run_command(
     instance: int,
-    input_queue: "queue.Queue[typing.Dict[str, typing.Any]]",
+    input_queue: "queue.Queue[dict[str, typing.Any]]",
     output_queue: "queue.Queue[float]",
     debug: bool = False,
 ) -> str | None:
@@ -48,9 +48,7 @@ def run_command(
 
     # These are not considered errors even though
     # we will end up with a segmented alignment
-    truncation_regex = re.compile(
-        r"truncating alignment (ending|starting) at \(\d+,\d+\);  anchor at \(\d+,\d+\)$"
-    )
+    truncation_regex = re.compile(r"truncating alignment (ending|starting) at \(\d+,\d+\);  anchor at \(\d+,\d+\)$")
     truncation_msg = "truncation can be reduced by using --allocate:traceback to increase traceback memory"
 
     while True:
@@ -64,7 +62,7 @@ def run_command(
 
         stdin = command_dict["stdin"]
         if stdin is not None:
-            stdin = open(stdin, "r")
+            stdin = open(stdin)
 
         stdout = command_dict["stdout"]
         if stdout is not None:
@@ -93,7 +91,7 @@ def run_command(
                     with open(stderr_file) as f:
                         for stderr_line in f:
                             stderr_line = stderr_line.strip()
-                            if (not truncation_regex.match(stderr_line) and stderr_line != truncation_msg):
+                            if not truncation_regex.match(stderr_line) and stderr_line != truncation_msg:
                                 stderr_ok = False
             except Exception:
                 stderr_ok = False
@@ -110,13 +108,13 @@ class BatchTar:
         self.pathname = pathname
         self.debug = debug
         self.tarfile = None
-        self.commands: typing.List[typing.Dict[str, typing.Any]] = []
+        self.commands: list[dict[str, typing.Any]] = []
         self.format_name = "tabular"
         self._extract()
         self._load_commands()
         self._load_format()
 
-    def batch_commands(self) -> typing.Iterator[typing.Dict[str, typing.Any]]:
+    def batch_commands(self) -> typing.Iterator[dict[str, typing.Any]]:
         for command in self.commands:
             yield command
 
@@ -125,9 +123,7 @@ class BatchTar:
 
     def _extract(self) -> None:
         try:
-            self.tarball = tarfile.open(
-                name=self.pathname, mode="r:*", format=tarfile.GNU_FORMAT
-            )
+            self.tarball = tarfile.open(name=self.pathname, mode="r:*", format=tarfile.GNU_FORMAT)
         except FileNotFoundError:
             sys.exit(f"ERROR: unable to find input tarball: {self.pathname}")
         except tarfile.ReadError:
@@ -139,17 +135,13 @@ class BatchTar:
         elapsed = time.perf_counter() - begin
 
         if self.debug:
-            print(
-                f"Extracted tarball in {elapsed} seconds", file=sys.stderr, flush=True
-            )
+            print(f"Extracted tarball in {elapsed} seconds", file=sys.stderr, flush=True)
 
     def _load_commands(self) -> None:
         try:
             f = open("galaxy/commands.json")
         except FileNotFoundError:
-            sys.exit(
-                f"ERROR: input tarball missing galaxy/commands.json: {self.pathname}"
-            )
+            sys.exit(f"ERROR: input tarball missing galaxy/commands.json: {self.pathname}")
 
         begin = time.perf_counter()
         for json_line in f:
@@ -157,9 +149,7 @@ class BatchTar:
             try:
                 command_dict = json.loads(json_line)
             except json.JSONDecodeError:
-                sys.exit(
-                    f"ERROR: bad json line in galaxy/commands.json: {self.pathname}"
-                )
+                sys.exit(f"ERROR: bad json line in galaxy/commands.json: {self.pathname}")
 
             self._load_command(command_dict)
 
@@ -173,9 +163,9 @@ class BatchTar:
                 flush=True,
             )
 
-    def _load_command(self, command_dict: typing.Dict[str, typing.Any]) -> None:
+    def _load_command(self, command_dict: dict[str, typing.Any]) -> None:
         # check command_dict structure
-        field_types: typing.Dict[str, typing.List[typing.Any]] = {
+        field_types: dict[str, list[typing.Any]] = {
             "executable": [str],
             "args": [list],
             "stdin": [str, "None"],
@@ -184,7 +174,7 @@ class BatchTar:
         }
 
         bad_format = False
-        for field_name in field_types.keys():
+        for field_name in field_types:
             # missing field
             if field_name not in command_dict:
                 bad_format = True
@@ -212,9 +202,7 @@ class BatchTar:
                     break
 
         if bad_format:
-            sys.exit(
-                f"ERROR: unexpected json format in line in galaxy/commands.json: {self.pathname}"
-            )
+            sys.exit(f"ERROR: unexpected json format in line in galaxy/commands.json: {self.pathname}")
 
         self.commands.append(command_dict)
 
@@ -239,7 +227,7 @@ class BatchTar:
             "sam": "sam",
             "sam-": "sam",
             "softsam": "sam",
-            "softsam-": "sam"
+            "softsam-": "sam",
         }
 
         self.format_name = format_map.get(format_name, "tabular")
@@ -258,8 +246,8 @@ class TarRunner:
         self.parallel = parallel
         self.debug = debug
         self.batch_tar = BatchTar(self.input_pathname, debug=self.debug)
-        self.output_file_format: typing.Dict[str, str] = {}
-        self.output_files: typing.Dict[str, typing.List[str]] = {}
+        self.output_file_format: dict[str, str] = {}
+        self.output_files: dict[str, list[str]] = {}
         self._set_output()
         self._set_target_query()
 
@@ -295,7 +283,7 @@ class TarRunner:
 
     def _set_target_query(self) -> None:
         for command_dict in self.batch_tar.batch_commands():
-            new_args: typing.List[str] = []
+            new_args: list[str] = []
 
             for arg in command_dict["args"]:
                 if arg.startswith("--target="):
@@ -312,7 +300,7 @@ class TarRunner:
         begin = time.perf_counter()
 
         with multiprocessing.Manager() as manager:
-            input_queue: queue.Queue[typing.Dict[str, typing.Any]] = manager.Queue()
+            input_queue: queue.Queue[dict[str, typing.Any]] = manager.Queue()
             output_queue: queue.Queue[float] = manager.Queue()
 
             for command_dict in self.batch_tar.batch_commands():
@@ -322,9 +310,7 @@ class TarRunner:
             for _ in range(self.parallel):
                 input_queue.put({})
 
-            with concurrent.futures.ProcessPoolExecutor(
-                max_workers=self.parallel
-            ) as executor:
+            with concurrent.futures.ProcessPoolExecutor(max_workers=self.parallel) as executor:
                 futures = [
                     executor.submit(
                         run_command,

--- a/scripts/runner.py
+++ b/scripts/runner.py
@@ -16,10 +16,20 @@ import typing
 
 SENTINEL_VALUE: typing.Final = "SENTINEL"
 # CA_SENTEL_VALUE: typing.Final = ChunkAddress(0, 0, 0, 0, 0, SENTINEL_VALUE)
-RUSAGE_ATTRS: typing.Final = ["ru_utime", "ru_stime", "ru_maxrss", "ru_minflt", "ru_majflt", "ru_inblock", "ru_oublock", "ru_nvcsw", "ru_nivcsw"]
+RUSAGE_ATTRS: typing.Final = [
+    "ru_utime",
+    "ru_stime",
+    "ru_maxrss",
+    "ru_minflt",
+    "ru_majflt",
+    "ru_inblock",
+    "ru_oublock",
+    "ru_nvcsw",
+    "ru_nivcsw",
+]
 
 
-def inject_inner(line: str, inner: typing.Optional[int]) -> str:
+def inject_inner(line: str, inner: int | None) -> str:
     if inner is None or " --inner=" in line:
         return line
 
@@ -48,17 +58,19 @@ class LastzCommands:
 
 
 class LastzCommand:
-    lastz_command_regex = re.compile(r"lastz (.+?)?ref\.2bit\[nameparse=darkspace\]\[multiple\]\[subset=ref_block(\d+)\.name\] (.+?)?query\.2bit\[nameparse=darkspace\]\[subset=query_block(\d+)\.name] --format=(\S+) --ydrop=(\d+) --gappedthresh=(\d+) --strand=(minus|plus)(?: --inner=(\d+))?(?: --ambiguous=(\S+))?(?: --(notrivial))?(?: --scores=(\S+))? --segments=tmp(\d+)\.block(\d+)\.r(\d+)\.(minus|plus)(?:\.split(\d+))?\.segments --output=tmp(\d+)\.block(\d+)\.r(\d+)\.(minus|plus)(?:\.split(\d+))?\.(\S+) 2> tmp(\d+)\.block(\d+)\.r(\d+)\.(minus|plus)(?:\.split(\d+))?\.err")
+    lastz_command_regex = re.compile(
+        r"lastz (.+?)?ref\.2bit\[nameparse=darkspace\]\[multiple\]\[subset=ref_block(\d+)\.name\] (.+?)?query\.2bit\[nameparse=darkspace\]\[subset=query_block(\d+)\.name] --format=(\S+) --ydrop=(\d+) --gappedthresh=(\d+) --strand=(minus|plus)(?: --inner=(\d+))?(?: --ambiguous=(\S+))?(?: --(notrivial))?(?: --scores=(\S+))? --segments=tmp(\d+)\.block(\d+)\.r(\d+)\.(minus|plus)(?:\.split(\d+))?\.segments --output=tmp(\d+)\.block(\d+)\.r(\d+)\.(minus|plus)(?:\.split(\d+))?\.(\S+) 2> tmp(\d+)\.block(\d+)\.r(\d+)\.(minus|plus)(?:\.split(\d+))?\.err"
+    )
 
     def __init__(self, line: str) -> None:
         self.line = line
         self.args: list[str] = []
-        self.target_filename: str = ''
-        self.query_filename: str = ''
-        self.data_folder: str = ''
+        self.target_filename: str = ""
+        self.query_filename: str = ""
+        self.data_folder: str = ""
         self.ref_block: int = 0
         self.query_block: int = 0
-        self.output_format: str = ''
+        self.output_format: str = ""
         self.ydrop: int = 0
         self.gappedthresh: int = 0
         self.inner: int | None = None
@@ -66,9 +78,9 @@ class LastzCommand:
         self.ambiguous: bool = False
         self.nontrivial: bool = False
         self.scoring: str | None = None
-        self.segments_filename: str = ''
-        self.output_filename: str = ''
-        self.error_filename: str = ''
+        self.segments_filename: str = ""
+        self.output_filename: str = ""
+        self.error_filename: str = ""
 
         self._parse_command()
 
@@ -85,13 +97,17 @@ class LastzCommand:
         self.gappedthresh = int(match.group(7))
         strand = match.group(8)
 
-        if strand == 'plus':
+        if strand == "plus":
             self.strand = 0
-        elif strand == 'minus':
+        elif strand == "minus":
             self.strand = 1
 
-        self.target_filename = f"{self.data_folder}ref.2bit[nameparse=darkspace][multiple][subset=ref_block{self.ref_block}.name]"
-        self.query_filename = f"{self.data_folder}query.2bit[nameparse=darkspace][subset=query_block{self.query_block}.name]"
+        self.target_filename = (
+            f"{self.data_folder}ref.2bit[nameparse=darkspace][multiple][subset=ref_block{self.ref_block}.name]"
+        )
+        self.query_filename = (
+            f"{self.data_folder}query.2bit[nameparse=darkspace][subset=query_block{self.query_block}.name]"
+        )
 
         self.args = [
             "lastz",
@@ -100,7 +116,7 @@ class LastzCommand:
             f"--format={self.output_format}",
             f"--ydrop={self.ydrop}",
             f"--gappedthresh={self.gappedthresh}",
-            f"--strand={strand}"
+            f"--strand={strand}",
         ]
 
         inner = match.group(9)
@@ -150,12 +166,14 @@ class KegAlignSegments:
         if filename not in self.segments:
             self.segments[filename] = KegAlignSegment(filename)
 
-    def __iter__(self) -> "KegAlignSegments":
-        return self
-
-    def __next__(self) -> typing.Generator["KegAlignSegment", None, None]:
-        for segment in sorted(self.segments.values()):
-            yield segment
+    # __iter__ used to return self alongside a __next__ that was itself a
+    # generator function, so every next() handed back a fresh generator object
+    # and never raised StopIteration: iterating this class looped forever and
+    # yielded generators rather than segments. Nothing called it, which is why
+    # it went unnoticed -- LastzCommands.segments() has no callers. mypy --strict
+    # reports it as an incompatible yield type.
+    def __iter__(self) -> typing.Iterator["KegAlignSegment"]:
+        yield from sorted(self.segments.values())
 
 
 class KegAlignSegment:
@@ -179,9 +197,9 @@ class KegAlignSegment:
         self.r = int(match.group(3))
 
         strand = match.group(4)
-        if strand == 'plus':
+        if strand == "plus":
             self.strand = 0
-        if strand == 'minus':
+        if strand == "minus":
             self.strand = 1
 
         split = match.group(5)
@@ -191,7 +209,7 @@ class KegAlignSegment:
             self.split = int(split)
 
     def __lt__(self, other: "KegAlignSegment") -> bool:
-        for attr in ['strand', 'tmp', 'block', 'r', 'split']:
+        for attr in ["strand", "tmp", "block", "r", "split"]:
             self_value = getattr(self, attr)
             other_value = getattr(other, attr)
             if self_value < other_value:
@@ -206,10 +224,7 @@ def main() -> None:
     args, kegalign_args = parse_args()
     lastz_commands = LastzCommands()
 
-    if args.diagonal_partition:
-        num_diagonal_partitioners = args.num_cpu
-    else:
-        num_diagonal_partitioners = 0
+    num_diagonal_partitioners = args.num_cpu if args.diagonal_partition else 0
 
     with multiprocessing.Manager() as manager:
         kegalign_q: queue.Queue[str] = manager.Queue()
@@ -247,7 +262,7 @@ def main() -> None:
         if args.output_type == "output":
             run_lastz(args, kegalign_q, lastz_commands)
 
-            with open(args.output_file, 'w') as of:
+            with open(args.output_file, "w") as of:
                 print("##maf version=1", file=of)
                 for lastz_command in lastz_commands.commands.values():
                     with open(lastz_command.output_filename) as f:
@@ -297,7 +312,9 @@ def lastz_worker(input_q: queue.Queue[str], instance: int, lastz_commands: Lastz
         command = lastz_commands.commands[line]
 
         if not os.path.exists(command.output_filename):
-            process = subprocess.run(command.args, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+            process = subprocess.run(
+                command.args, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+            )
 
             for line in process.stdout.splitlines():
                 print(line, file=sys.stdout, flush=True)
@@ -310,7 +327,9 @@ def lastz_worker(input_q: queue.Queue[str], instance: int, lastz_commands: Lastz
                 sys.exit(f"Error: lastz {instance} exited with returncode {process.returncode}")
 
 
-def run_diagonal_partitioners(args: argparse.Namespace, num_workers: int, input_q: queue.Queue[str], output_q: queue.Queue[str]) -> None:
+def run_diagonal_partitioners(
+    args: argparse.Namespace, num_workers: int, input_q: queue.Queue[str], output_q: queue.Queue[str]
+) -> None:
     chunk_size = estimate_chunk_size(args)
 
     if args.debug:
@@ -321,7 +340,9 @@ def run_diagonal_partitioners(args: argparse.Namespace, num_workers: int, input_
             executor.submit(diagonal_partition_worker(args, input_q, output_q, chunk_size, i))
 
 
-def diagonal_partition_worker(args: argparse.Namespace, input_q: queue.Queue[str], output_q: queue.Queue[str], chunk_size: int, instance: int) -> None:
+def diagonal_partition_worker(
+    args: argparse.Namespace, input_q: queue.Queue[str], output_q: queue.Queue[str], chunk_size: int, instance: int
+) -> None:
     while True:
         line = input_q.get()
         if line == SENTINEL_VALUE:
@@ -331,7 +352,9 @@ def diagonal_partition_worker(args: argparse.Namespace, input_q: queue.Queue[str
         run_args = ["python", f"{args.tool_directory}/diagonal_partition.py", str(chunk_size)]
         for word in line.split():
             run_args.append(word)
-        process = subprocess.run(run_args, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE, stderr=subprocess.PIPE, bufsize=1, text=True)
+        process = subprocess.run(
+            run_args, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE, stderr=subprocess.PIPE, bufsize=1, text=True
+        )
 
         for line in process.stdout.splitlines():
             output_q.put(line)
@@ -355,7 +378,7 @@ def estimate_chunk_size(args: argparse.Namespace) -> int:
 
     # get size of each segment assuming DELETE_AFTER_CHUNKING == True
     # takes into account already split segments
-    fdict: typing.DefaultDict[str, int] = collections.defaultdict(int)
+    fdict: collections.defaultdict[str, int] = collections.defaultdict(int)
     for entry in os.scandir("."):
         if entry.name.endswith(".segments"):
             try:
@@ -396,7 +419,13 @@ def estimate_chunk_size(args: argparse.Namespace) -> int:
     return chunk_size
 
 
-def run_kegalign(args: argparse.Namespace, num_sentinel: int, kegalign_args: list[str], kegalign_q: queue.Queue[str], commands: LastzCommands) -> bool:
+def run_kegalign(
+    args: argparse.Namespace,
+    num_sentinel: int,
+    kegalign_args: list[str],
+    kegalign_q: queue.Queue[str],
+    commands: LastzCommands,
+) -> bool:
     skip_kegalign: bool = False
 
     # use the currently existing output file if it exists
@@ -442,7 +471,7 @@ def run_kegalign(args: argparse.Namespace, num_sentinel: int, kegalign_args: lis
     return skip_kegalign
 
 
-def load_kegalign_output(filename: str, inner: typing.Optional[int], kegalign_q: queue.Queue[str]) -> bool:
+def load_kegalign_output(filename: str, inner: int | None, kegalign_q: queue.Queue[str]) -> bool:
     load_success = False
 
     r_beg = resource.getrusage(resource.RUSAGE_SELF)
@@ -472,14 +501,26 @@ def load_kegalign_output(filename: str, inner: typing.Optional[int], kegalign_q:
 def parse_args() -> tuple[argparse.Namespace, list[str]]:
     parser = argparse.ArgumentParser(allow_abbrev=False)
 
-    parser.add_argument("--output-type", nargs="?", const="commands", default="commands", type=str, choices=["commands", "output", "tarball"], help="output type (default: %(default)s)")
+    parser.add_argument(
+        "--output-type",
+        nargs="?",
+        const="commands",
+        default="commands",
+        type=str,
+        choices=["commands", "output", "tarball"],
+        help="output type (default: %(default)s)",
+    )
     parser.add_argument("--output-file", type=str, required=True, help="output pathname")
     parser.add_argument("--diagonal-partition", action="store_true", help="run diagonal partition optimization")
     parser.add_argument("--nogapped", action="store_true", help="don't perform gapped extension stage")
     parser.add_argument("--markend", action="store_true", help="write a marker line just before completion")
     parser.add_argument("--inner", type=int, help="pass --inner to LASTZ command generation and execution")
-    parser.add_argument("--num-gpu", default=-1, type=int, help="number of GPUs to use (default: %(default)s [use all GPUs])")
-    parser.add_argument("--num-cpu", default=-1, type=int, help="number of CPUs to use (default: %(default)s [use all CPUs])")
+    parser.add_argument(
+        "--num-gpu", default=-1, type=int, help="number of GPUs to use (default: %(default)s [use all GPUs])"
+    )
+    parser.add_argument(
+        "--num-cpu", default=-1, type=int, help="number of CPUs to use (default: %(default)s [use all CPUs])"
+    )
     parser.add_argument("--debug", action="store_true", help="print debug messages")
     parser.add_argument("--tool_directory", type=str, required=True, help="tool directory")
 


### PR DESCRIPTION
The repository already declared a Python convention — `scripts/mypy.ini` **and** `scripts/mps-mig/mypy.ini` both set `strict = True` — but nothing ran either, so neither the style nor the typing was enforced and both had drifted. This adds ruff (config, autofixes, formatting) and wires it into the existing workflow.

`target-version` is `py312` because the conda-forge `kegalign` recipe pins `python 3.12.*`. Raising it would let ruff emit `UP043`/`UP037` rewrites which parse on 3.12 but raise `TypeError` there at runtime.

**Mechanical:** 51 safe autofixes plus a format pass over six files.

## Not mechanical — please read these

- **`KegAlignSegments` iteration never terminated.** `__iter__` returned `self` alongside a `__next__` that was itself a generator function, so every `next()` handed back a fresh generator object and never raised `StopIteration`. Iterating the class looped forever, yielding generators instead of segments. Nothing calls it (`LastzCommands.segments()` has no callers), which is why it went unnoticed.
- **`GPU_queue.__len__` raised `NameError`** — it referred to `gpu_queue`, a name that exists only as a local inside `main()`. Now uses `self`. This does *not* make the MPS/MIG driver work: `NamedPopen.__init__` forwards `name=` to `subprocess.Popen` and raises `TypeError` several lines earlier. That is fixed in the stacked branch.
- **Three `--unsafe-fixes`**: `SIM108` (ternary in `main()`), `SIM118`, `PLR1722` (bare `exit()` → `sys.exit()`), plus `SIM117` merging two `with` statements and `PLR1730` rewriting two `if` blocks as `min()`. Behaviour-preserving on inspection, but edits a reviewer should read rather than skim.
- **A NON-BREAKING HYPHEN** in a comment, rendering as `--format=none` without being that string.

## Deliberately not fixed

Two dead locals in `run_mig.py` are in `per-file-ignores` rather than deleted: `no_MIG` is computed and announced with `"Using non-MIG GPU"` but never read, and `non_mig_gpu_id` sits under its own `TODO make this non hardcoded`. Those read as an unfinished code path — someone who knows the intent should decide, not a linter.

Remaining pre-existing violations are listed with counts and a reason. A review found three of those counts wrong; they are recomputed against this branch.

`__pycache__/` is added to `.gitignore`.

---

**First of three stacked branches.** Merge order: this → *Actually run the diagonal partitioners in parallel* → *Do not ask for a quantile of fewer than two data points*.
