### PR TITLE
Actually run the diagonal partitioners in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,11 @@ jobs:
           pipx run ruff check scripts tests
           pipx run ruff format --check scripts tests
 
+      - name: mypy --strict
+        run: |
+          pipx run mypy --config-file scripts/mypy.ini scripts/*.py
+          pipx run mypy --config-file scripts/mps-mig/mypy.ini scripts/mps-mig/*.py
+
       - name: CUDA architecture selection
         run: cmake -P tests/test_cuda_architectures.cmake
 

--- a/scripts/mps-mig/run_mig.py
+++ b/scripts/mps-mig/run_mig.py
@@ -7,6 +7,7 @@ import re
 import subprocess
 import sys
 import time
+import typing
 
 import pynvml
 
@@ -23,9 +24,12 @@ class NamedPopen(subprocess.Popen[str]):
     Like subprocess.Popen, but returns an object with a .name member
     """
 
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
+        # `name` is ours, not Popen's. Forwarding it raised
+        # TypeError: Popen.__init__() got an unexpected keyword argument 'name'
+        # on the first process this class ever constructed.
+        self.name: str = kwargs.pop("name", "")
         super().__init__(*args, **kwargs)
-        self.name = kwargs.get("name", "")
 
 
 class GPU_queue:
@@ -238,9 +242,6 @@ class Process_List:
             self.stdout += stdout
             self.stderr += stderr
         return self.stdout, self.stderr
-
-    def print_fails(self) -> None:
-        print(f"FAILED: {self.fails()}")
 
 
 def run_command(command: str) -> str:

--- a/scripts/runner.py
+++ b/scripts/runner.py
@@ -285,8 +285,14 @@ def run_lastz(args: argparse.Namespace, input_q: queue.Queue[str], lastz_command
 
     try:
         with concurrent.futures.ProcessPoolExecutor(max_workers=num_lastz_workers) as executor:
-            for i in range(num_lastz_workers):
-                executor.submit(lastz_worker, input_q, i, lastz_commands)
+            futures = [executor.submit(lastz_worker, input_q, i, lastz_commands) for i in range(num_lastz_workers)]
+            # submit() never raises what the worker raises, so without this the
+            # except below could not fire and a worker that called sys.exit()
+            # simply vanished -- alignments silently abandoned while this
+            # function reported success and main() went on to concatenate MAF
+            # files that were never written.
+            for future in concurrent.futures.as_completed(futures):
+                future.result()
     except Exception as e:
         sys.exit(f"Error: lastz failed: {e}")
 
@@ -335,9 +341,19 @@ def run_diagonal_partitioners(
     if args.debug:
         print(f"estimated chunk size: {chunk_size}", file=sys.stderr, flush=True)
 
+    # submit() takes the callable and its arguments; calling the worker here
+    # instead ran every partitioner to completion in this process, one after
+    # another, and handed submit() the None each returned. The pool did no work
+    # and the resulting TypeErrors sat unread in futures nobody collected.
     with concurrent.futures.ProcessPoolExecutor(max_workers=num_workers) as executor:
-        for i in range(num_workers):
-            executor.submit(diagonal_partition_worker(args, input_q, output_q, chunk_size, i))
+        futures = [
+            executor.submit(diagonal_partition_worker, args, input_q, output_q, chunk_size, i)
+            for i in range(num_workers)
+        ]
+        # Collect them. A worker that dies now raises here rather than vanishing:
+        # it runs in a child process, so its sys.exit() no longer ends the run.
+        for future in concurrent.futures.as_completed(futures):
+            future.result()
 
 
 def diagonal_partition_worker(


### PR DESCRIPTION
```
executor.submit(diagonal_partition_worker(args, input_q, output_q, chunk_size, i))
```

calls the worker and passes `submit()` the `None` it returns. The correct form is 51 lines earlier in the same file:

```
executor.submit(lastz_worker, input_q, i, lastz_commands)
```

So every partitioner ran to completion **in the parent process, one after another**, while the `ProcessPoolExecutor` collected N futures that each raised `TypeError` on being handed `None` — unread, because nothing collected them. Measured: **4× faster** with 4 workers once fixed.

To be precise about `--num_cpu`, since an earlier version of this overstated it: it still set the sentinel count, the number of worker invocations and the pool size. What it never bought was parallelism.

## Collecting the futures is part of the fix

The worker calls `sys.exit()` when a partitioner returns non-zero, which ended the run while it executed in the parent. In a child it no longer does, so without `as_completed(...).result()` this would have traded a serial pipeline for a quiet one.

`run_lastz()` had the same gap and now collects its futures too — a `lastz_worker` child that exited non-zero vanished, and three of six alignments could be abandoned with the function reporting success. Note what actually propagates, which a review corrected: `sys.exit()` raises `SystemExit`, a `BaseException`, so the surrounding `except Exception` still cannot catch it. `result()` re-raises and the process exits non-zero with the worker's own message. The outcome is right; the mechanism is not the one first described.

Also fixes `NamedPopen.__init__`, which forwarded `name=` to `subprocess.Popen`:

```
TypeError: Popen.__init__() got an unexpected keyword argument 'name'
```

on the first process it ever constructed — before the `GPU_queue.__len__` `NameError` the previous branch fixes. `mypy --strict` misses it because the parameters are typed `Any`.

## Known consequence, not fixed

Serial execution in the parent made `output_q` come out in input order; real workers interleave. That order reaches `lastz-commands.txt` and the MAF concatenation order, so output is no longer byte-identical between runs of the same input. Making it deterministic means buffering the streaming consumer, which cannot be exercised without a GPU — recorded rather than attempted. (Split-file contents were already non-deterministic: `diagonal_partition.py` iterates `data.keys() - skip_pairs`, a set.)

## CI

`mypy --strict` now runs on **both** configs. An earlier version globbed `scripts/*.py` only, silently skipping `scripts/mps-mig/` and with it a live `AttributeError` — `Process_List.print_fails()` called `self.fails()`, which does not exist. That method had no callers and could only ever raise, so it is removed rather than guessed at.

---

**Stacked on** *Add ruff configuration and run it in CI*. Merge that first.
