### PR TITLE
Do not ask for a quantile of fewer than two data points

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,16 @@ jobs:
       - name: LASTZ scoring file is read in full
         run: bash tests/test_scoring.bash
 
+      # The bug this guards is interpreter-dependent: statistics.quantiles()
+      # raises on one data point up to 3.12 and returns it from 3.13. Pin 3.12,
+      # which is what the conda-forge kegalign recipe ships, or the named case
+      # silently stops being covered when the runner image advances.
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: runner.py chunk-size estimation
+        run: python tests/test_chunk_size.py
       - name: ruff
         run: |
           pipx run ruff check scripts tests

--- a/scripts/diagonal_partition.py
+++ b/scripts/diagonal_partition.py
@@ -137,6 +137,13 @@ if __name__ == "__main__":
         # add 1 for newline
         line_size = len(f.readline())
 
+    # An empty segments file gives readline() == "" and so line_size == 0. The
+    # worker sys.exit()s on our non-zero return, so a ZeroDivisionError here ends
+    # the whole run -- after the GPU work is done.
+    if line_size <= 0:
+        print(" ".join(params), flush=True)
+        sys.exit(0)
+
     estimated_lines = file_size // line_size
 
     # check if chunk size should be estimated
@@ -160,7 +167,15 @@ if __name__ == "__main__":
                 f_ = filename.split(".split", 1)[0]
                 fdict[f_] += size
 
-            if len(fdict) < 7:
+            # statistics.quantiles() needs two data points on Python 3.10-3.12,
+            # one on 3.13+. The `len(files) < 2` test above does not supply that:
+            # files are keyed by prefix here, so the two split files
+            # DELETE_AFTER_CHUNKING itself produces -- a.split1.segments and
+            # a.split2.segments -- are len(files) == 2 but len(fdict) == 1.
+            # Same defect as runner.py's estimate_chunk_size(), second copy.
+            if len(fdict) < 2:
+                chunk_size = MAX_CHUNK_SIZE
+            elif len(fdict) < 7:
                 # outliers can heavily skew prediction if <7 data points
                 # to be safe, use 50% quantile
                 chunk_size = int(statistics.quantiles(fdict.values())[1] // line_size)

--- a/scripts/runner.py
+++ b/scripts/runner.py
@@ -402,7 +402,12 @@ def estimate_chunk_size(args: argparse.Namespace) -> int:
             except FileNotFoundError:
                 continue
 
-            if line_size == -1:
+            if line_size <= 0:
+                # Latch from the first file that actually has a line. An empty
+                # segments file returns "" here, and a 0 would otherwise stick:
+                # the old `== -1` test never retried, so one empty file arriving
+                # first from os.scandir() (whose order is not defined) poisoned
+                # the estimate for the whole run.
                 try:
                     with open(entry.name) as f:
                         line_size = len(f.readline())  # add 1 for newline
@@ -411,7 +416,22 @@ def estimate_chunk_size(args: argparse.Namespace) -> int:
 
             fdict[entry.name.split(".split", 1)[0]] += file_size
 
-    if len(fdict) < 7:
+    # statistics.quantiles() needs at least two data points on Python 3.10-3.12,
+    # and one on 3.13+; the <7 branch below guarantees neither. A run whose
+    # alignment is sparse enough to produce a single .segments file reaches it
+    # with 1 and dies with an unhandled StatisticsError -- after the GPU work is
+    # already done. Zero files raises on every version.
+    #
+    # line_size is 0 for an empty first line, which divides by zero. (It also
+    # stays -1 when no file can be opened, but that path is unreachable: the
+    # same FileNotFoundError skips the fdict update, so fdict is empty and the
+    # quantile call fails first.)
+    if not fdict or line_size <= 0:
+        chunk_size = MAX_CHUNK_SIZE
+    elif len(fdict) == 1:
+        # one file: use it directly rather than asking for a quantile of it
+        chunk_size = int(next(iter(fdict.values())) // line_size)
+    elif len(fdict) < 7:
         # outliers can heavily skew prediction if <7 data points
         # to be safe, use 50% quantile
         chunk_size = int(statistics.quantiles(fdict.values())[1] // line_size)
@@ -421,6 +441,13 @@ def estimate_chunk_size(args: argparse.Namespace) -> int:
 
     # if not enough data points, there is a chance of getting unlucky
     # minimize worst case by using MAX_CHUNK_SIZE
+    #
+    # Do NOT clamp the lower end. 0 is a documented value, not an error:
+    # diagonal_partition.py says "set <max-segments> = 0 to skip partitioning"
+    # and passes the command through untouched. Flooring it at 1 would turn that
+    # no-op into one output file and one LASTZ command per segment line, for
+    # every file in the run, because chunk_size is estimated once and applied to
+    # all of them.
 
     chunk_size = min(chunk_size, MAX_CHUNK_SIZE)
 

--- a/tests/test_chunk_size.py
+++ b/tests/test_chunk_size.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""estimate_chunk_size() must survive a sparse alignment.
+
+Run with:  python3 tests/test_chunk_size.py
+
+statistics.quantiles() needs at least two data points on Python 3.10-3.12 and at
+least one on 3.13+. runner.py guarded only the "<7 data points" case, so a run
+whose alignment produced a single .segments file reached it with 1 and died with
+an unhandled StatisticsError -- after the GPU work was already finished:
+
+    File "runner.py", line 378, in estimate_chunk_size
+      chunk_size = int(statistics.quantiles(fdict.values())[1] // line_size)
+    statistics.StatisticsError: must have at least two data points
+
+Observed on a real run: two sequences with a literal X every 500 bases, sparse
+enough to yield one segments file. The conda-forge kegalign recipe pins
+python 3.12.*, so that is the interpreter the shipped package uses.
+
+This imports the real estimate_chunk_size() and drives it against temporary
+directories of .segments files. It deliberately does NOT re-implement the
+arithmetic: a copy would keep passing while runner.py drifted away from it.
+"""
+
+import argparse
+import importlib.util
+import os
+import pathlib
+import sys
+import tempfile
+
+HERE = pathlib.Path(__file__).resolve().parent
+RUNNER = HERE.parent / "scripts" / "runner.py"
+
+failures: list[str] = []
+
+
+def load_runner():
+    """Import scripts/runner.py without running its __main__ block."""
+    spec = importlib.util.spec_from_file_location("kegalign_runner", RUNNER)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def check(label, got, want):
+    if got != want:
+        print(f"not ok - {label}\n     got: {got}\nexpected: {want}")
+        failures.append(label)
+    else:
+        print(f"ok - {label}")
+
+
+def run_in(files, line):
+    """Call the real estimate_chunk_size() in a temp dir holding `files`.
+
+    files: {name: number_of_lines}. `line` is the text of each line, so the
+    caller controls line_size, which the function infers from the first line of
+    the first file it opens.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        for name, count in files.items():
+            (pathlib.Path(tmp) / name).write_text(line * count)
+        cwd = os.getcwd()
+        try:
+            os.chdir(tmp)
+            return runner.estimate_chunk_size(argparse.Namespace(debug=False))
+        finally:
+            os.chdir(cwd)
+
+
+runner = load_runner()
+MAX_CHUNK_SIZE = 50000
+LINE = "chr1\t1\t100\tchr2\t1\t100\t+\t1000\n"  # 27 bytes
+
+check("no segments files at all", run_in({}, LINE), MAX_CHUNK_SIZE)
+check("one segments file (the observed crash)", run_in({"a.segments": 100}, LINE), 100)
+check("two segments files", run_in({"a.segments": 100, "b.segments": 200}, LINE), 150)
+check(
+    "eight segments files",
+    run_in({f"{c}.segments": 10 * (i + 1) for i, c in enumerate("abcdefgh")}, LINE),
+    67,
+)
+check(
+    "a lone empty file yields MAX_CHUNK_SIZE, not a division by zero", run_in({"a.segments": 0}, LINE), MAX_CHUNK_SIZE
+)
+check("a one-character line is a valid divisor", run_in({"a.segments": 3}, "\n"), 3)
+# An empty file must not poison line_size for the files that follow it. Ten good
+# files plus one empty one used to give either the right answer or MAX_CHUNK_SIZE
+# depending on os.scandir() order.
+check(
+    "one empty file among good ones does not poison the estimate",
+    run_in({"empty.segments": 0, **{f"g{i}.segments": 100 for i in range(10)}}, LINE),
+    100,
+)
+# 0 is diagonal_partition.py's documented "skip partitioning" value -- it prints
+# the command unchanged and exits. Flooring the estimate at 1 would turn that
+# no-op into one output file and one LASTZ command per segment line, for every
+# file in the run. Reaching 0 through estimate_chunk_size() needs the quantile to
+# fall below line_size, which depends on which file os.scandir() latches
+# line_size from and so cannot be constructed deterministically. Assert the
+# absence of the clamp instead, and pin the contract at the other end.
+source = RUNNER.read_text()
+check("no lower clamp on the estimate", "max(1, min(chunk_size" in source, False)
+check(
+    "diagonal_partition.py still treats 0 as skip-partitioning",
+    "if chunk_size == 0:" in (RUNNER.parent / "diagonal_partition.py").read_text(),
+    True,
+)
+check("non-.segments files are ignored", run_in({"a.txt": 100, "b.log": 200}, LINE), MAX_CHUNK_SIZE)
+check(
+    "result is clamped to MAX_CHUNK_SIZE",
+    run_in({"a.segments": 10**6, "b.segments": 10**6}, "x\n"),
+    MAX_CHUNK_SIZE,
+)
+
+if failures:
+    print(f"\n{len(failures)} test(s) failed")
+    sys.exit(1)
+print("\nall tests passed")


### PR DESCRIPTION
`statistics.quantiles()` needs **two** data points on Python 3.10–3.12 and one on 3.13+. Two estimators in this repository ask it for a quantile without guaranteeing either.

**`runner.py`** guards the `<7 data points` case but not the case that breaks: a run whose alignment is sparse enough to produce a single `.segments` file reaches it with 1 and dies with an unhandled `StatisticsError` — after all the GPU work is done. Observed on a real Galaxy run, two ~20 kb sequences with a literal `X` every 500 bases:

```
File "runner.py", line 378, in estimate_chunk_size
  chunk_size = int(statistics.quantiles(fdict.values())[1] // line_size)
statistics.StatisticsError: must have at least two data points
```

**`diagonal_partition.py`** has its own copy of the same expression, reached with `--segment_size -1`, and its `len(files) < 2` test does not cover it: files are keyed by *prefix* there, so the two split files `DELETE_AFTER_CHUNKING` itself produces — `a.split1.segments`, `a.split2.segments` — are `len(files) == 2` but `len(fdict) == 1`. A code review found this second copy; the first version of this change fixed only `runner.py`.

The conda-forge `kegalign` recipe pins `python 3.12.*`, so that is the interpreter the shipped package runs. (`kegalign-full` is `noarch` and declares no python of its own.)

## Division by `line_size`

Guarded in both files. It is 0 for an empty segments file, and `diagonal_partition.py` divides by its own freshly-derived copy — so fixing only `runner.py` moved the same crash one process further along, where the worker's `sys.exit()` ends the run anyway. Verified before and after: `ZeroDivisionError`, then a clean pass-through.

`line_size` was also latched from the first `.segments` file `os.scandir()` returned and never retried, so one empty file arriving first poisoned the estimate for the whole run.

## Not clamped: the lower end

An earlier version floored the result with `max(1, ...)`, reasoning that "0 is not a valid chunk size." **That was wrong.** `diagonal_partition.py:10` documents *"set `<max-segments>` = 0 to skip partitioning"* and implements it by printing the command unchanged. Flooring at 1 would turn that no-op into one output file and one LASTZ command per segment line — for every file in the run, since the estimate is computed once and applied to all of them.

## Tests

`tests/test_chunk_size.py` **imports** the real `estimate_chunk_size()` and drives it against temporary directories. An earlier version re-implemented the arithmetic; a review showed the bug could be fully restored with that test green, and two of its expected values were wrong in ways the copy hid.

CI pins python 3.12 for it: the behaviour under test is interpreter-dependent, and on 3.13+ the single-file case passes even with the fix reverted. Mutation-checked on 3.12 — restoring the bug fails the suite; changing `MAX_CHUNK_SIZE` fails 4 of the 11 checks.

---

**Last of three stacked branches.** Merge after *Add ruff configuration* and *Actually run the diagonal partitioners in parallel*.
