### PR TITLE
Concatenate MAF output in a deterministic order

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
 
       - name: runner.py chunk-size estimation
         run: python tests/test_chunk_size.py
+
+      - name: MAF output order is deterministic
+        run: python tests/test_output_order.py
       - name: ruff
         run: |
           pipx run ruff check scripts tests

--- a/scripts/runner.py
+++ b/scripts/runner.py
@@ -56,6 +56,22 @@ class LastzCommands:
         for segment in self.kegalign_segments:
             yield segment
 
+    def sorted_commands(self) -> list["LastzCommand"]:
+        """Commands in the order SegAlign concatenated its output.
+
+        The shell implementation this replaced ran lastz in parallel and then
+        concatenated deterministically:
+
+            for i in tmp*.plus.*;  do echo $i; done | sort -V
+            for i in tmp*.minus.*; do echo $i; done | sort -V
+
+        KegAlignSegment.__lt__ already encodes exactly that order -- strand
+        first (plus=0, minus=1), then tmp, block, r, split -- it was simply
+        never called. self.commands is insertion-ordered, i.e. whatever order
+        the partitioners happened to emit.
+        """
+        return sorted(self.commands.values(), key=lambda c: KegAlignSegment(c.segments_filename))
+
 
 class LastzCommand:
     lastz_command_regex = re.compile(
@@ -264,7 +280,7 @@ def main() -> None:
 
             with open(args.output_file, "w") as of:
                 print("##maf version=1", file=of)
-                for lastz_command in lastz_commands.commands.values():
+                for lastz_command in lastz_commands.sorted_commands():
                     with open(lastz_command.output_filename) as f:
                         for line in f:
                             of.write(line)

--- a/tests/test_output_order.py
+++ b/tests/test_output_order.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""MAF output order must not depend on which partitioner finished first.
+
+Run with:  python3 tests/test_output_order.py
+
+The shell implementation KegAlign replaced ran lastz in parallel and then
+concatenated deterministically, plus before minus, version-sorted within each:
+
+    for i in tmp*.plus.*;  do echo $i; done | sort -V
+    for i in tmp*.minus.*; do echo $i; done | sort -V
+
+The Python port dropped that: main() iterated lastz_commands.commands.values(),
+which is insertion order -- whatever order the diagonal partitioners emitted.
+That was masked for as long as the partitioners accidentally ran serially in the
+parent process; once they actually run in parallel, the same input produces MAF
+blocks in a different order run to run.
+
+KegAlignSegment.__lt__ already encoded the intended order and was never called.
+"""
+
+import importlib.util
+import pathlib
+import random
+import sys
+
+RUNNER = pathlib.Path(__file__).resolve().parent.parent / "scripts" / "runner.py"
+failures: list[str] = []
+
+
+def load_runner():
+    spec = importlib.util.spec_from_file_location("kegalign_runner", RUNNER)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def check(label, got, want):
+    if got != want:
+        print(f"not ok - {label}\n     got: {got}\nexpected: {want}")
+        failures.append(label)
+    else:
+        print(f"ok - {label}")
+
+
+runner = load_runner()
+
+TEMPLATE = (
+    "lastz ref.2bit[nameparse=darkspace][multiple][subset=ref_block{r}.name] "
+    "query.2bit[nameparse=darkspace][subset=query_block{b}.name] --format=maf "
+    "--ydrop=9430 --gappedthresh=3000 --strand={s} "
+    "--segments=tmp{t}.block{b}.r{r}.{s}.segments "
+    "--output=tmp{t}.block{b}.r{r}.{s}.maf 2> tmp{t}.block{b}.r{r}.{s}.err"
+)
+
+lines = [
+    TEMPLATE.format(t=t, b=b, r=r, s=s) for s in ("plus", "minus") for t in (0, 1, 2) for b in (0, 1) for r in (0,)
+]
+
+
+def order_of(shuffled):
+    commands = runner.LastzCommands()
+    for line in shuffled:
+        commands.add(line)
+    return [c.output_filename for c in commands.sorted_commands()]
+
+
+expected = order_of(lines)
+
+# plus must come before minus, matching SegAlign's two loops
+first_minus = next(i for i, f in enumerate(expected) if ".minus." in f)
+last_plus = max(i for i, f in enumerate(expected) if ".plus." in f)
+check("all plus files precede all minus files", last_plus < first_minus, True)
+check("first file is tmp0.block0.r0.plus", expected[0], "tmp0.block0.r0.plus.maf")
+
+# and the order must not depend on the order the commands arrived in
+rng = random.Random(11)
+stable = True
+for _ in range(25):
+    shuffled = lines[:]
+    rng.shuffle(shuffled)
+    if order_of(shuffled) != expected:
+        stable = False
+        break
+check("order is identical across 25 shuffled arrival orders", stable, True)
+
+# the unsorted path is what regressed; show it actually differs
+unsorted = list(runner.LastzCommands().commands.values())
+shuffled = lines[:]
+rng.shuffle(shuffled)
+c = runner.LastzCommands()
+for line in shuffled:
+    c.add(line)
+insertion = [x.output_filename for x in c.commands.values()]
+check("insertion order really is different (so the sort is load-bearing)", insertion != expected, True)
+
+# The checks above exercise sorted_commands() directly, so they stay green if the
+# method is correct but main() never calls it -- which is exactly the regression.
+# Assert the call site too. (Mutation-checked: reverting either the sort key or
+# the call site turns this file red.)
+source = RUNNER.read_text()
+check(
+    "main() concatenates via sorted_commands(), not commands.values()",
+    "for lastz_command in lastz_commands.sorted_commands():" in source,
+    True,
+)
+check(
+    "the unsorted concatenation is gone",
+    "for lastz_command in lastz_commands.commands.values():" in source,
+    False,
+)
+
+if failures:
+    print(f"\n{len(failures)} test(s) failed")
+    sys.exit(1)
+print("\nall tests passed")


### PR DESCRIPTION
`main()` built the MAF by iterating `lastz_commands.commands.values()` — a dict in insertion order, i.e. whatever order the diagonal partitioners happened to emit. The same input therefore produced MAF blocks in a different order run to run.

## This is a regression against SegAlign, not a consequence of anything new

The shell implementation KegAlign replaced ran lastz in parallel and then concatenated deterministically:

```bash
for i in tmp*.plus.*;  do echo $i; done | sort -V
for i in tmp*.minus.*; do echo $i; done | sort -V
```

The Python port dropped that guarantee. The loss stayed invisible only because the partitioners were accidentally running serially in the parent process, so arrival order happened to be input order. Fixing that (#54) did not create the non-determinism — it made a pre-existing one observable.

## The intended ordering was already in the code

`KegAlignSegment.__lt__` compares on `["strand", "tmp", "block", "r", "split"]` with `plus=0` and `minus=1` — exactly SegAlign's two loops, plus first, version-ordered within each. It had never been called. Its only would-be caller was `KegAlignSegments.__iter__`, which until #53 looped forever and had no callers.

That method looks like a half-finished port of the `sort -V` step: the comparison written, the iteration broken, the call site never wired up. `sorted_commands()` finishes it.

**No buffering.** The output queue is still consumed as it streams; only the concatenation at the end is ordered.

## Test

`tests/test_output_order.py` shuffles the arrival order 25 ways and requires an identical result each time, checks plus precedes minus, and asserts `main()` calls `sorted_commands()`.

That last assertion is not decoration. Mutation-checked: the behavioural checks alone stay **green** when the call site reverts to `commands.values()`, because they exercise the method directly. Reverting either the sort key or the call site now turns the file red.
