### PR TITLE
Order the command file too, not just the MAF

### DIFF
--- a/scripts/runner.py
+++ b/scripts/runner.py
@@ -259,20 +259,29 @@ def main() -> None:
         if args.output_type == "commands":
             output_filename = args.output_file
 
+        # The lines arrive in whatever order the diagonal partitioners finish,
+        # so the file they are written to -- and commands.json, which
+        # package_output.py builds from it line by line -- would differ between
+        # runs of the same input. lastz is still fed as the lines stream in;
+        # only the file is ordered, and only at the end.
+        output_lines: list[str] = []
+        while True:
+            line = output_q.get()
+            if line == SENTINEL_VALUE:
+                output_q.task_done()
+                break
+
+            # messy, fix this
+            if skip_kegalign:
+                lastz_commands.add(line)
+
+            if args.output_type != "commands":
+                kegalign_q.put(line)
+
+            output_lines.append(line)
+
         with open(output_filename, "w") as f:
-            while True:
-                line = output_q.get()
-                if line == SENTINEL_VALUE:
-                    output_q.task_done()
-                    break
-
-                # messy, fix this
-                if skip_kegalign:
-                    lastz_commands.add(line)
-
-                if args.output_type != "commands":
-                    kegalign_q.put(line)
-
+            for line in sorted(output_lines, key=lastz_command_sort_key):
                 print(line, file=f)
 
         if args.output_type == "output":
@@ -396,6 +405,20 @@ def diagonal_partition_worker(
 
         if process.returncode != 0:
             sys.exit(f"Error: diagonal partitioner {instance} exited with returncode {process.returncode}")
+
+
+def lastz_command_sort_key(line: str) -> "KegAlignSegment":
+    """Order a lastz command line the way SegAlign ordered its output files.
+
+    KegAlignSegment.__lt__ compares on strand (plus=0, minus=1), tmp, block, r
+    and split -- the same order `sort -V` over tmp*.plus.* then tmp*.minus.*
+    produced in scripts/run_segalign.
+    """
+    match = re.search(r"--segments=(\S+)", line)
+    if match is None:
+        sys.exit(f"Error: no --segments= in lastz command: {line}")
+
+    return KegAlignSegment(match.group(1))
 
 
 def estimate_chunk_size(args: argparse.Namespace) -> int:

--- a/tests/test_output_order.py
+++ b/tests/test_output_order.py
@@ -94,6 +94,30 @@ for line in shuffled:
 insertion = [x.output_filename for x in c.commands.values()]
 check("insertion order really is different (so the sort is load-bearing)", insertion != expected, True)
 
+# The commands FILE is a separate path from the MAF concatenation, and it is the
+# one Galaxy hands downstream: package_output.py builds commands.json from it
+# line by line. Measured on a real GPU run before this was fixed -- two runs of
+# the same input gave the same 21 commands in different orders, one starting
+# tmp11.plus and the other tmp3.minus.
+shuffled = lines[:]
+rng.shuffle(shuffled)
+by_key = sorted(shuffled, key=runner.lastz_command_sort_key)
+check(
+    "the command file order is stable regardless of arrival order",
+    all(sorted(rng.sample(lines, len(lines)), key=runner.lastz_command_sort_key) == by_key for _ in range(20)),
+    True,
+)
+check(
+    "the command file puts plus before minus",
+    ".plus." in by_key[0] and ".minus." in by_key[-1],
+    True,
+)
+check(
+    "main() writes the command file sorted",
+    "for line in sorted(output_lines, key=lastz_command_sort_key):" in RUNNER.read_text(),
+    True,
+)
+
 # The checks above exercise sorted_commands() directly, so they stay green if the
 # method is correct but main() never calls it -- which is exactly the regression.
 # Assert the call site too. (Mutation-checked: reverting either the sort key or


### PR DESCRIPTION
PR #56 sorted the MAF concatenation and left the other output path alone. The lastz command file is written from the output queue as lines arrive, and `package_output.py` builds `galaxy/commands.json` from it line by line — so the artifact Galaxy hands downstream was still in partitioner-completion order.

## Measured, not reasoned about

Two runs of the same input through a Galaxy 25.0 instance on 4× A100, `--num_cpu 8`:

```
run 1  commands.json  21 lines, 8807 bytes, starts tmp11.block0.r0.plus
run 2  commands.json  21 lines, 8807 bytes, starts tmp3.block0.r0.minus
```

Same 21 commands, same byte count, different order. That is what #56 was meant to eliminate and did not, because it only reached the MAF path.

## The fix

`lastz_command_sort_key()` pulls the segments filename out of the command line and defers to `KegAlignSegment.__lt__`, so both output paths now order by the same rule SegAlign used: strand first (plus, then minus), then tmp, block, r, split.

lastz is still fed as the lines stream in. Only the file write is deferred, and only to the end of a loop that was already reading the whole queue.

## Test

Verified against the 21 command lines from that run: stable across 20 shuffled arrival orders, plus before minus. The test also asserts the call site, because the behavioural checks alone stay green if the sort is written and never used — the same gap this commit exists to close in #56.
