### PR TITLE
Release v0.3.1

### DIFF
--- a/common/parameters.h
+++ b/common/parameters.h
@@ -1,4 +1,4 @@
-#define VERSION "v0.3.0"
+#define VERSION "v0.3.1"
 
 // Upper bound on a seed pattern's weight (its count of match positions).
 //


### PR DESCRIPTION
A patch bump. Nothing in the aligner changed: the only C++ edit is a CLI guard that rejects input v0.3.0 accepted and then corrupted GPU memory on.

The rest is the orchestration layer, where every defect found after v0.3.0 turned out to live.

| PR | |
|---|---|
| #52 | Reject seed patterns below weight 4. `GenerateSeedPosTable()` asserts `kmer_size > 3` and `NDEBUG` deletes that assert, so a weight-3 pattern reached the GPU and died with `cudaErrorIllegalAddress`. |
| #53 | ruff configuration, and run it in CI. The repository already declared a Python convention — two `mypy.ini` files setting `strict = True` — and had never run it. Also fixes a class whose iteration never terminated and a `__len__` that raised `NameError`. |
| #54 | Actually run the diagonal partitioners in parallel. `executor.submit()` was passed the worker's return value instead of the worker, so every partitioner ran serially in the parent while the pool collected futures that each raised `TypeError`, unread. `--num_cpu` has never bought any parallelism for this stage in any released version. Measured 4× with 4 workers. `run_lastz()` had the same gap and could abandon alignments while reporting success. |
| #55 | Guard `statistics.quantiles()` against fewer than two data points, in **both** estimators that call it. A sparse alignment produced one `.segments` file and died with an unhandled `StatisticsError` after all the GPU work was done. |
| #56, #57 | Concatenate MAF output deterministically, and the command file too. SegAlign sorted with `sort -V`; the Python port lost that, and the loss stayed invisible only because #54's bug made execution accidentally serial. Two runs of the same input gave the same 21 commands in different orders on 4× A100. |
| #58 | `docs/implementation-notes.md` gains a section on the orchestration layer, which had none, plus the seed weight floor and the index-table cost. |

Verified on merged `main`: ruff, both `mypy --strict` configs, and all four host-side suites green. The parallel partitioners and the ordering fix were exercised end to end through a Galaxy instance on 4× A100 — the first time that code path has run concurrently anywhere.

`tests/check_version.bash` passes against `v0.3.1` and fails against `v0.3.0`.
